### PR TITLE
fix: issue #94 raise from exceptions

### DIFF
--- a/semantic_router/encoders/cohere.py
+++ b/semantic_router/encoders/cohere.py
@@ -25,7 +25,9 @@ class CohereEncoder(BaseEncoder):
         try:
             self.client = cohere.Client(cohere_api_key)
         except Exception as e:
-            raise ValueError(f"Cohere API client failed to initialize. Error: {e}")
+            raise ValueError(
+                f"Cohere API client failed to initialize. Error: {e}"
+            ) from e
 
     def __call__(self, docs: List[str]) -> List[List[float]]:
         if self.client is None:
@@ -34,4 +36,4 @@ class CohereEncoder(BaseEncoder):
             embeds = self.client.embed(docs, input_type="search_query", model=self.name)
             return embeds.embeddings
         except Exception as e:
-            raise ValueError(f"Cohere API call failed. Error: {e}")
+            raise ValueError(f"Cohere API call failed. Error: {e}") from e

--- a/semantic_router/encoders/fastembed.py
+++ b/semantic_router/encoders/fastembed.py
@@ -48,4 +48,4 @@ class FastEmbedEncoder(BaseEncoder):
             embeddings: List[List[float]] = [e.tolist() for e in embeds]
             return embeddings
         except Exception as e:
-            raise ValueError(f"FastEmbed embed failed. Error: {e}")
+            raise ValueError(f"FastEmbed embed failed. Error: {e}") from e

--- a/semantic_router/encoders/openai.py
+++ b/semantic_router/encoders/openai.py
@@ -29,7 +29,9 @@ class OpenAIEncoder(BaseEncoder):
         try:
             self.client = openai.Client(api_key=api_key)
         except Exception as e:
-            raise ValueError(f"OpenAI API client failed to initialize. Error: {e}")
+            raise ValueError(
+                f"OpenAI API client failed to initialize. Error: {e}"
+            ) from e
 
     def __call__(self, docs: List[str]) -> List[List[float]]:
         if self.client is None:
@@ -49,7 +51,7 @@ class OpenAIEncoder(BaseEncoder):
                 logger.warning(f"Retrying in {2**j} seconds...")
             except Exception as e:
                 logger.error(f"OpenAI API call failed. Error: {error_message}")
-                raise ValueError(f"OpenAI API call failed. Error: {e}")
+                raise ValueError(f"OpenAI API call failed. Error: {e}") from e
 
         if (
             not embeds

--- a/semantic_router/encoders/zure.py
+++ b/semantic_router/encoders/zure.py
@@ -74,7 +74,9 @@ class AzureOpenAIEncoder(BaseEncoder):
                 # _strict_response_validation=True,
             )
         except Exception as e:
-            raise ValueError(f"OpenAI API client failed to initialize. Error: {e}")
+            raise ValueError(
+                f"OpenAI API client failed to initialize. Error: {e}"
+            ) from e
 
     def __call__(self, docs: List[str]) -> List[List[float]]:
         if self.client is None:
@@ -100,7 +102,7 @@ class AzureOpenAIEncoder(BaseEncoder):
                 logger.warning(f"Retrying in {2**j} seconds...")
             except Exception as e:
                 logger.error(f"Azure OpenAI API call failed. Error: {error_message}")
-                raise ValueError(f"Azure OpenAI API call failed. Error: {e}")
+                raise ValueError(f"Azure OpenAI API call failed. Error: {e}") from e
 
         if (
             not embeds

--- a/semantic_router/llms/cohere.py
+++ b/semantic_router/llms/cohere.py
@@ -24,7 +24,9 @@ class CohereLLM(BaseLLM):
         try:
             self.client = cohere.Client(cohere_api_key)
         except Exception as e:
-            raise ValueError(f"Cohere API client failed to initialize. Error: {e}")
+            raise ValueError(
+                f"Cohere API client failed to initialize. Error: {e}"
+            ) from e
 
     def __call__(self, messages: List[Message]) -> str:
         if self.client is None:
@@ -43,4 +45,4 @@ class CohereLLM(BaseLLM):
             return output
 
         except Exception as e:
-            raise ValueError(f"Cohere API call failed. Error: {e}")
+            raise ValueError(f"Cohere API call failed. Error: {e}") from e

--- a/semantic_router/llms/openai.py
+++ b/semantic_router/llms/openai.py
@@ -29,7 +29,9 @@ class OpenAILLM(BaseLLM):
         try:
             self.client = openai.OpenAI(api_key=api_key)
         except Exception as e:
-            raise ValueError(f"OpenAI API client failed to initialize. Error: {e}")
+            raise ValueError(
+                f"OpenAI API client failed to initialize. Error: {e}"
+            ) from e
         self.temperature = temperature
         self.max_tokens = max_tokens
 
@@ -51,4 +53,4 @@ class OpenAILLM(BaseLLM):
             return output
         except Exception as e:
             logger.error(f"LLM error: {e}")
-            raise Exception(f"LLM error: {e}")
+            raise Exception(f"LLM error: {e}") from e

--- a/semantic_router/llms/openrouter.py
+++ b/semantic_router/llms/openrouter.py
@@ -34,7 +34,9 @@ class OpenRouterLLM(BaseLLM):
         try:
             self.client = openai.OpenAI(api_key=api_key, base_url=self.base_url)
         except Exception as e:
-            raise ValueError(f"OpenRouter API client failed to initialize. Error: {e}")
+            raise ValueError(
+                f"OpenRouter API client failed to initialize. Error: {e}"
+            ) from e
         self.temperature = temperature
         self.max_tokens = max_tokens
 
@@ -56,4 +58,4 @@ class OpenRouterLLM(BaseLLM):
             return output
         except Exception as e:
             logger.error(f"LLM error: {e}")
-            raise Exception(f"LLM error: {e}")
+            raise Exception(f"LLM error: {e}") from e

--- a/semantic_router/utils/llm.py
+++ b/semantic_router/utils/llm.py
@@ -32,7 +32,7 @@ def llm(prompt: str) -> Optional[str]:
         return output
     except Exception as e:
         logger.error(f"LLM error: {e}")
-        raise Exception(f"LLM error: {e}")
+        raise Exception(f"LLM error: {e}") from e
 
 
 # TODO integrate async LLM function
@@ -62,4 +62,4 @@ def llm(prompt: str) -> Optional[str]:
 #         return output
 #     except Exception as e:
 #         logger.error(f"LLM error: {e}")
-#         raise Exception(f"LLM error: {e}")
+#         raise Exception(f"LLM error: {e}") from e


### PR DESCRIPTION
## Suggestion In order to resolve issue #94 

this PR uses the **raise from** idiom in order to wrap caught exceptions with additional context while preserving their original stack traces.

## Notes
The original issue required the exception in [semantic-router/semantic_router/llms/openai.py](https://github.com/aurelio-labs/semantic-router/blob/f8fcd43a7018d6216668250ff99d9acbe7f16789/semantic_router/llms/openai.py#L53) be re-raised, but this PR addresses similar occurrences of this pattern while preserving the additional context added by the new raised exceptions.