### PR TITLE
fix: Saving JSON/YAML of Layer Config

### DIFF
--- a/semantic_router/route.py
+++ b/semantic_router/route.py
@@ -68,8 +68,18 @@ class Route(BaseModel):
             func_call = None
         return RouteChoice(name=self.name, function_call=func_call)
 
+    # def to_dict(self) -> Dict[str, Any]:
+    #     return self.dict()
+    
     def to_dict(self) -> Dict[str, Any]:
-        return self.dict()
+        data = self.dict()
+        if self.llm is not None:
+            data['llm'] = {
+                'module': self.llm.__module__,
+                'class': self.llm.__class__.__name__,
+                'model': self.llm.name
+            }
+        return data
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]):


### PR DESCRIPTION
Saving Layer Configs as JSON or YAML config files by representing the `LayerConfig` object as a `dict` and then turning into JSON/YAML wasn't working.

See issue here: https://github.com/aurelio-labs/semantic-router/issues/144

The issue was that, by attempting this, we were attempting to serialize all objects included in the Layer, including `Routes`, and the `llm`'s that those `Routes` use.

In the case of the above issue, the `llm` was a Cohere one, which included a `Client` as one of its attributes, and this `Client` is not serializable.

So, instead of attempting to represent the entire `llm` object a `dict`, to then be converted into JSON/YAML, we only keep key information about the `llm`:

```
'module': self.llm.__module__,
'class': self.llm.__class__.__name__,
'model': self.llm.name
```

This is amongs the information saved to a `dict` in `route.py`, and then sent to `layer.py` to be serialized (in `LayerConfig.to_file()`).

Then, when it comes time to load from the file via `LayerConfig.from_file()`, the `llm` is re-initialized dynamically.