### PR TITLE
Added ollama.py

### DIFF
--- a/semantic_router/llms/ollama.py
+++ b/semantic_router/llms/ollama.py
@@ -1,0 +1,37 @@
+import os
+from typing import List, Optional
+import requests
+import json
+
+from semantic_router.llms import BaseLLM
+from semantic_router.schema import Message
+from semantic_router.utils.logger import logger
+
+
+class OllamaLLM(BaseLLM):
+    max_tokens: Optional[int] = 200
+
+
+    def _call_(self, messages: List[Message]) -> str:
+        
+        try:
+
+            payload = {
+                "model": self.name,
+                "messages": [m.to_openai() for m in messages],
+                "options":{
+                    "temperature":0.0,
+                    "num_predict":self.max_tokens
+                },
+                "format":"json",
+                "stream":False
+            }
+
+            response = requests.post("http://localhost:11434/api/chat", json=payload)
+         
+            output = response.json()["message"]["content"]
+
+            return output
+        except Exception as e:
+            logger.error(f"LLM error: {e}")
+            raise Exception(f"LLM error: {e}") from e


### PR DESCRIPTION
Adding Ollama support.
Ollama uses Llama cpp under the hood and has a JSON grammar option enabled by setting the format to JSON.

payload = {
                "model": self.name,
                "messages": [m.to_openai() for m in messages],
                "options":{
                    "temperature":0.0,
                    "num_predict":self.max_tokens
                },
                "format":"json",
                "stream":False
            }

To use just pass the model name 

from ollama import OllamaLLM
llm = OllamaLLM(name="openhermes")
rl = RouteLayer(encoder = encoder, routes=routes, llm=llm)