### PR TITLE
feat: openai encoder org id support

### DIFF
--- a/semantic_router/encoders/openai.py
+++ b/semantic_router/encoders/openai.py
@@ -29,7 +29,7 @@ class OpenAIEncoder(BaseEncoder):
         super().__init__(name=name, score_threshold=score_threshold)
         api_key = openai_api_key or os.getenv("OPENAI_API_KEY")
         openai_org_id = openai_org_id or os.getenv("OPENAI_ORG_ID")
-        if (api_key is None):
+        if api_key is None:
             raise ValueError("OpenAI API key cannot be 'None'.")
         try:
             self.client = openai.Client(api_key=api_key, organization=openai_org_id)

--- a/semantic_router/encoders/openai.py
+++ b/semantic_router/encoders/openai.py
@@ -28,11 +28,11 @@ class OpenAIEncoder(BaseEncoder):
             name = os.getenv("OPENAI_MODEL_NAME", "text-embedding-ada-002")
         super().__init__(name=name, score_threshold=score_threshold)
         api_key = openai_api_key or os.getenv("OPENAI_API_KEY")
-        org_id = openai_org_id or os.getenv("OPENAI_ORGANIZATION")
-        if (api_key is None) and (org_id is None):
+        openai_org_id = openai_org_id or os.getenv("OPENAI_ORG_ID")
+        if (api_key is None):
             raise ValueError("OpenAI API key cannot be 'None'.")
         try:
-            self.client = openai.Client(api_key=api_key, organization=org_id)
+            self.client = openai.Client(api_key=api_key, organization=openai_org_id)
         except Exception as e:
             raise ValueError(
                 f"OpenAI API client failed to initialize. Error: {e}"

--- a/semantic_router/encoders/openai.py
+++ b/semantic_router/encoders/openai.py
@@ -20,6 +20,7 @@ class OpenAIEncoder(BaseEncoder):
         self,
         name: Optional[str] = None,
         openai_api_key: Optional[str] = None,
+        openai_org_id: Optional[str] = None,
         score_threshold: float = 0.82,
         dimensions: Union[int, NotGiven] = NotGiven(),
     ):
@@ -27,10 +28,13 @@ class OpenAIEncoder(BaseEncoder):
             name = os.getenv("OPENAI_MODEL_NAME", "text-embedding-ada-002")
         super().__init__(name=name, score_threshold=score_threshold)
         api_key = openai_api_key or os.getenv("OPENAI_API_KEY")
-        if api_key is None:
+        print(f"api key: {api_key}")
+        org_id = openai_org_id or os.getenv("OPENAI_ORGANIZATION")
+        print(f"org id: {org_id}")
+        if (api_key is None) and (org_id is None):
             raise ValueError("OpenAI API key cannot be 'None'.")
         try:
-            self.client = openai.Client(api_key=api_key)
+            self.client = openai.Client(api_key=api_key, organization=org_id)
         except Exception as e:
             raise ValueError(
                 f"OpenAI API client failed to initialize. Error: {e}"

--- a/semantic_router/encoders/openai.py
+++ b/semantic_router/encoders/openai.py
@@ -28,9 +28,7 @@ class OpenAIEncoder(BaseEncoder):
             name = os.getenv("OPENAI_MODEL_NAME", "text-embedding-ada-002")
         super().__init__(name=name, score_threshold=score_threshold)
         api_key = openai_api_key or os.getenv("OPENAI_API_KEY")
-        print(f"api key: {api_key}")
         org_id = openai_org_id or os.getenv("OPENAI_ORGANIZATION")
-        print(f"org id: {org_id}")
         if (api_key is None) and (org_id is None):
             raise ValueError("OpenAI API key cannot be 'None'.")
         try:

--- a/tests/unit/encoders/test_openai.py
+++ b/tests/unit/encoders/test_openai.py
@@ -14,7 +14,9 @@ def openai_encoder(mocker):
 
 class TestOpenAIEncoder:
     def test_openai_encoder_init_success(self, mocker):
-        mocker.patch("os.getenv", return_value="fake-api-key")
+        # -- Mock the return value of os.getenv 3 times: model name, api key and org ID
+        side_effect = ["fake-model-name", "fake-api-key", "fake-org-id"]
+        mocker.patch("os.getenv", side_effect=side_effect)
         encoder = OpenAIEncoder()
         assert encoder.client is not None
 


### PR DESCRIPTION
Adding support for `OPENAI_ORGANIZATION` when initialising the `OpenAIEncoder`.
This PR includes:
- The code changes to support this feature
- Minor updates to the unit tests to ensure this functionality works as expected