### PR TITLE
feat: create cloud saving/loading of route layers

### DIFF
--- a/semantic_router/layer.py
+++ b/semantic_router/layer.py
@@ -4,6 +4,7 @@ import os
 import random
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from datasets import load_dataset
 import numpy as np
 import yaml
 from tqdm.auto import tqdm
@@ -285,6 +286,14 @@ class RouteLayer:
     def from_config(cls, config: LayerConfig):
         encoder = Encoder(type=config.encoder_type, name=config.encoder_name).model
         return cls(encoder=encoder, routes=config.routes)
+    
+    @classmethod
+    def from_hub(cls, route_layer_id: str):
+        data = load_dataset(route_layer_id, split="train")
+        # transform dataset into list of Route objects
+        routes = [Route(**data[i]) for i in range(len(data))]
+        return cls(routes=routes)
+
 
     def add(self, route: Route):
         logger.info(f"Adding `{route.name}` route")
@@ -418,6 +427,9 @@ class RouteLayer:
     def to_yaml(self, file_path: str):
         config = self.to_config()
         config.to_file(file_path)
+
+    def to_hub(self, route_layer_id: str, api_key: str):
+        raise NotImplementedError("To be implemented")
 
     def get_thresholds(self) -> Dict[str, float]:
         # TODO: float() below is hacky fix for lint, fix this with new type?


### PR DESCRIPTION
We will add a "Route Hub" which for the foreseeable future will using Hugging Face Hub as a "RouteLayer repository" allowing users to save, load, and share route layers.

Should include:

- [ ] Saving/loading of all `Routes` in a route layer, including their thresholds, any function calling schema, and description
- [ ] Saving/loading of encoder information
- [ ] Anything else needed to make saving/loading fully automated and easy
- [ ] Tagging system on HF so we and users can filter for and search specifically for route layer datasets on HF

Users will need an HF account and API keys for this to work.

Can refer to [this example](https://github.com/aurelio-labs/semantic-router/blob/main/docs/examples/pinecone-and-scaling.ipynb) for a minimal version of this functionality