### PR TITLE
fix: kwarg LlamaCppLLM.llm overwritten by import

### DIFF
--- a/semantic_router/llms/llamacpp.py
+++ b/semantic_router/llms/llamacpp.py
@@ -41,8 +41,6 @@ class LlamaCppLLM(BaseLLM):
                 "`pip install 'semantic-router[local]'`"
             )
         self._llama_cpp = llama_cpp
-        llm = self._llama_cpp.Llama
-        grammar = self._llama_cpp.LlamaGrammar
         self.llm = llm
         self.temperature = temperature
         self.max_tokens = max_tokens


### PR DESCRIPTION
Closes #206 .

## Description of fix

A bug was introduced in #190 that overwrote the kwarg value of `LlamaCppLLM.llm`, replacing a passed kwarg instance of `llama_cpp.Llama`.

The same bug also replaced the passed value of `LlamaCppLLM.grammar`.

## Fix

Rely on `self._llama_cpp.{Llama,LlamaGrammar}` if we need these classes, remove the overriding of `llm` and `grammar` from the values passed as kwargs.