### PR TITLE
feat: multiple route choices

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ While we encourage you to initiate a draft Pull Request early to get feedback on
     # Move into the cloned folder
     cd semantic-router/
 
-    # Create a virtual environment
+    # Create a virtual environment. NOTE: Use Python 3.11 or below until fastembed is updated to version 0.2.6.
     python3 -m venv venv
 
     # Activate the environment

--- a/tests/functional/test_layer.py
+++ b/tests/functional/test_layer.py
@@ -1,0 +1,63 @@
+import importlib
+import os
+
+import pytest
+
+from semantic_router.encoders.openai import OpenAIEncoder
+from semantic_router.index.local import LocalIndex
+from semantic_router.index.pinecone import PineconeIndex
+from semantic_router.index.qdrant import QdrantIndex
+from semantic_router.layer import RouteLayer
+from semantic_router.route import Route
+
+
+def mock_encoder_call(utterances):
+    # Define a mapping of utterances to return values
+    mock_responses = {
+        "Hello": [0.1, 0.2, 0.3],
+        "Hi": [0.4, 0.5, 0.6],
+        "Goodbye": [0.7, 0.8, 0.9],
+        "Bye": [1.0, 1.1, 1.2],
+        "Au revoir": [1.3, 1.4, 1.5],
+    }
+    return [mock_responses.get(u, [0.0, 0.0, 0.0]) for u in utterances]
+
+
+@pytest.fixture
+def openai_encoder(mocker):
+    mocker.patch.object(OpenAIEncoder, "__call__", side_effect=mock_encoder_call)
+    return OpenAIEncoder(name="test-openai-encoder", openai_api_key="test_api_key")
+
+
+@pytest.fixture
+def routes():
+    return [
+        Route(name="Route 1", utterances=["Hello", "Hi"]),
+        Route(name="Route 2", utterances=["Goodbye", "Bye", "Au revoir"]),
+    ]
+
+
+def get_test_indexes():
+    indexes = [LocalIndex]
+
+    if importlib.util.find_spec("qdrant_client") is not None:
+        indexes.append(QdrantIndex)
+    return indexes
+
+
+@pytest.mark.parametrize("index_cls", get_test_indexes())
+class TestRouteLayerIntegration:
+    def test_query_filter_pinecone(self, openai_encoder, routes, index_cls):
+        pinecone_api_key = os.environ["PINECONE_API_KEY"]
+        pineconeindex = PineconeIndex(api_key=pinecone_api_key)
+        route_layer = RouteLayer(
+            encoder=openai_encoder, routes=routes, index=pineconeindex
+        )
+        query_result = route_layer(text="Hello", route_filter=["Route 1"]).name
+
+        try:
+            route_layer(text="Hello", route_filter=["Route 8"]).name
+        except ValueError:
+            assert True
+
+        assert query_result in ["Route 1"]

--- a/tests/unit/test_layer.py
+++ b/tests/unit/test_layer.py
@@ -7,7 +7,6 @@ import pytest
 
 from semantic_router.encoders import BaseEncoder, CohereEncoder, OpenAIEncoder
 from semantic_router.index.local import LocalIndex
-from semantic_router.index.pinecone import PineconeIndex
 from semantic_router.index.qdrant import QdrantIndex
 from semantic_router.layer import LayerConfig, RouteLayer
 from semantic_router.llms.base import BaseLLM
@@ -257,21 +256,6 @@ class TestRouteLayer:
 
         assert query_result in ["Route 1"]
 
-    def test_query_filter_pinecone(self, openai_encoder, routes, index_cls):
-        pinecone_api_key = os.environ["PINECONE_API_KEY"]
-        pineconeindex = PineconeIndex(api_key=pinecone_api_key)
-        route_layer = RouteLayer(
-            encoder=openai_encoder, routes=routes, index=pineconeindex
-        )
-        query_result = route_layer(text="Hello", route_filter=["Route 1"]).name
-
-        try:
-            route_layer(text="Hello", route_filter=["Route 8"]).name
-        except ValueError:
-            assert True
-
-        assert query_result in ["Route 1"]
-
     def test_query_with_no_index(self, openai_encoder, index_cls):
         route_layer = RouteLayer(encoder=openai_encoder, index=index_cls())
         with pytest.raises(ValueError):
@@ -296,12 +280,14 @@ class TestRouteLayer:
         route_layer = RouteLayer(
             encoder=openai_encoder, routes=routes, index=index_cls()
         )
-        classification, score = route_layer._semantic_classify(
+        classifications_with_scores = route_layer._semantic_classify(
             [
                 {"route": "Route 1", "score": 0.9},
                 {"route": "Route 2", "score": 0.1},
             ]
         )
+        assert len(classifications_with_scores) == 2
+        classification, score = classifications_with_scores[0]
         assert classification == "Route 1"
         assert score == [0.9]
 
@@ -309,13 +295,15 @@ class TestRouteLayer:
         route_layer = RouteLayer(
             encoder=openai_encoder, routes=routes, index=index_cls()
         )
-        classification, score = route_layer._semantic_classify(
+        classifications_with_scores = route_layer._semantic_classify(
             [
                 {"route": "Route 1", "score": 0.9},
                 {"route": "Route 2", "score": 0.1},
                 {"route": "Route 1", "score": 0.8},
             ]
         )
+        assert len(classifications_with_scores) == 2
+        classification, score = classifications_with_scores[0]
         assert classification == "Route 1"
         assert score == [0.9, 0.8]
 
@@ -629,7 +617,10 @@ class TestLayerConfig:
                 routes=routes,
                 aggregation=agg,
             )
-            classification, score = route_layer._semantic_classify(route_scores)
+
+            classification_with_scores = route_layer._semantic_classify(route_scores)
+
+            classification, score = classification_with_scores[0]
 
             if agg == "sum":
                 assert classification == "Route 1"


### PR DESCRIPTION
Implementation for multiple route choices returned from a call:
#89 https://github.com/aurelio-labs/semantic-router/issues/89

Currently only for RouteLayer, not for HybridRouteLayer. Also - need to update documentation (where?)