### PR TITLE
fix: Added fix to encode documents within rolling window

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Pytest
         env:
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           make test
       - name: Upload coverage to Codecov

--- a/semantic_router/encoders/base.py
+++ b/semantic_router/encoders/base.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List
 
 from pydantic.v1 import BaseModel, Field
 
@@ -11,5 +11,5 @@ class BaseEncoder(BaseModel):
     class Config:
         arbitrary_types_allowed = True
 
-    def __call__(self, docs: List[str]) -> List[List[float]]:
+    def __call__(self, docs: List[Any]) -> List[List[float]]:
         raise NotImplementedError("Subclasses must implement this method")

--- a/semantic_router/index/base.py
+++ b/semantic_router/index/base.py
@@ -20,7 +20,7 @@ class BaseIndex(BaseModel):
     type: str = "base"
 
     def add(
-        self, embeddings: List[List[float]], routes: List[str], utterances: List[str]
+        self, embeddings: List[List[float]], routes: List[str], utterances: List[Any]
     ):
         """
         Add embeddings to the index.

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -122,7 +122,7 @@ class PineconeIndex(BaseIndex):
             time.sleep(0.5)
         elif index_exists:
             # if the index exists we just return it
-            index = self.client.Index(self.index_name, namespace=self.namespace)
+            index = self.client.Index(self.index_name)
             # grab the dimensions from the index
             self.dimensions = index.describe_index_stats()["dimension"]
         elif force_create and not dimensions_given:
@@ -234,7 +234,7 @@ class PineconeIndex(BaseIndex):
     def delete(self, route_name: str):
         route_vec_ids = self._get_route_ids(route_name=route_name)
         if self.index is not None:
-            self.index.delete(ids=route_vec_ids)
+            self.index.delete(ids=route_vec_ids, namespace=self.namespace)
         else:
             raise ValueError("Index is None, could not delete.")
 

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -49,12 +49,27 @@ class PineconeIndex(BaseIndex):
     ServerlessSpec: Any = Field(default=None, exclude=True)
     namespace: Optional[str] = ""
 
-    def __init__(self, **data):
-        super().__init__(**data)
-        self._initialize_client()
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        index_name: str = "index",
+        dimensions: Optional[int] = None,
+        metric: str = "cosine",
+        cloud: str = "aws",
+        region: str = "us-west-2",
+        host: str = "",
+        namespace: Optional[str] = "",
+    ):
+        super().__init__()
+        self.index_name = index_name
+        self.dimensions = dimensions
+        self.metric = metric
+        self.cloud = cloud
+        self.region = region
+        self.host = host
+        self.namespace = namespace
         self.type = "pinecone"
-        self.client = self._initialize_client()
-        self.index = self._init_index(force_create=True)
+        self.client = self._initialize_client(api_key=api_key)
 
     def _initialize_client(self, api_key: Optional[str] = None):
         try:
@@ -77,6 +92,18 @@ class PineconeIndex(BaseIndex):
         return Pinecone(**pinecone_args)
 
     def _init_index(self, force_create: bool = False) -> Union[Any, None]:
+        """Initializing the index can be done after the object has been created
+        to allow for the user to set the dimensions and other parameters.
+
+        If the index doesn't exist and the dimensions are given, the index will
+        be created. If the index exists, it will be returned. If the index doesn't
+        exist and the dimensions are not given, the index will not be created and
+        None will be returned.
+
+        :param force_create: If True, the index will be created even if the
+            dimensions are not given (which will raise an error).
+        :type force_create: bool, optional
+        """
         index_exists = self.index_name in self.client.list_indexes().names()
         dimensions_given = self.dimensions is not None
         if dimensions_given and not index_exists:

--- a/semantic_router/layer.py
+++ b/semantic_router/layer.py
@@ -354,7 +354,7 @@ class RouteLayer:
     def add(self, route: Route):
         logger.info(f"Adding `{route.name}` route")
         # create embeddings
-        embeds = self.encoder(route.utterances)  # type: ignore
+        embeds = self.encoder(route.utterances)
         # if route has no score_threshold, use default
         if route.score_threshold is None:
             route.score_threshold = self.score_threshold
@@ -363,7 +363,7 @@ class RouteLayer:
         self.index.add(
             embeddings=embeds,
             routes=[route.name] * len(route.utterances),
-            utterances=route.utterances,  # type: ignore
+            utterances=route.utterances,
         )
         self.routes.append(route)
 
@@ -409,14 +409,14 @@ class RouteLayer:
         all_utterances = [
             utterance for route in routes for utterance in route.utterances
         ]
-        embedded_utterances = self.encoder(all_utterances)  # type: ignore
+        embedded_utterances = self.encoder(all_utterances)
         # create route array
         route_names = [route.name for route in routes for _ in route.utterances]
         # add everything to the index
         self.index.add(
             embeddings=embedded_utterances,
             routes=route_names,
-            utterances=all_utterances,  # type: ignore
+            utterances=all_utterances,
         )
 
     def _encode(self, text: str) -> Any:

--- a/semantic_router/splitters/rolling_window.py
+++ b/semantic_router/splitters/rolling_window.py
@@ -100,19 +100,12 @@ class RollingWindowSplitter(BaseSplitter):
         return splits
 
     def _encode_documents(self, docs: List[str]) -> np.ndarray:
-        max_docs_per_batch = 2000  # OpenAI limit is 2048
-        embeddings = []
-
-        for i in range(0, len(docs), max_docs_per_batch):
-            batch_docs = docs[i : i + max_docs_per_batch]
-            try:
-                batch_embeddings = self.encoder(batch_docs)
-                embeddings.extend(batch_embeddings)
-            except Exception as e:
-                logger.error(f"Error encoding documents {batch_docs}: {e}")
-                raise
-
-        return np.array(embeddings)
+        try:
+            embeddings = self.encoder(docs)
+            return np.array(embeddings)
+        except Exception as e:
+            logger.error(f"Error encoding documents {docs}: {e}")
+            raise
 
     def _calculate_similarity_scores(self, encoded_docs: np.ndarray) -> List[float]:
         raw_similarities = []

--- a/semantic_router/splitters/rolling_window.py
+++ b/semantic_router/splitters/rolling_window.py
@@ -100,12 +100,19 @@ class RollingWindowSplitter(BaseSplitter):
         return splits
 
     def _encode_documents(self, docs: List[str]) -> np.ndarray:
-        try:
-            embeddings = self.encoder(docs)
-            return np.array(embeddings)
-        except Exception as e:
-            logger.error(f"Error encoding documents {docs}: {e}")
-            raise
+        max_docs_per_batch = 2000  # OpenAI limit is 2048
+        embeddings = []
+
+        for i in range(0, len(docs), max_docs_per_batch):
+            batch_docs = docs[i : i + max_docs_per_batch]
+            try:
+                batch_embeddings = self.encoder(batch_docs)
+                embeddings.extend(batch_embeddings)
+            except Exception as e:
+                logger.error(f"Error encoding documents {batch_docs}: {e}")
+                raise
+
+        return np.array(embeddings)
 
     def _calculate_similarity_scores(self, encoded_docs: np.ndarray) -> List[float]:
         raw_similarities = []

--- a/tests/unit/test_layer.py
+++ b/tests/unit/test_layer.py
@@ -288,9 +288,6 @@ class TestRouteLayer:
         except ValueError:
             assert True
 
-        # delete index
-        pineconeindex.delete_index()
-
         assert query_result in ["Route 1"]
 
     def test_namespace_pinecone_index(self, openai_encoder, routes, index_cls):
@@ -306,9 +303,6 @@ class TestRouteLayer:
             route_layer(text="Hello", route_filter=["Route 8"]).name
         except ValueError:
             assert True
-
-        # delete index
-        pineconeindex.delete_index()
 
         assert query_result in ["Route 1"]
 

--- a/tests/unit/test_layer.py
+++ b/tests/unit/test_layer.py
@@ -280,7 +280,7 @@ class TestRouteLayer:
         route_layer = RouteLayer(
             encoder=openai_encoder, routes=routes, index=pineconeindex
         )
-        time.sleep(10)  # allow for index to be populated
+        time.sleep(5)  # allow for index to be populated
         query_result = route_layer(text="Hello", route_filter=["Route 1"]).name
 
         try:
@@ -299,7 +299,7 @@ class TestRouteLayer:
         route_layer = RouteLayer(
             encoder=openai_encoder, routes=routes, index=pineconeindex
         )
-        time.sleep(10)  # allow for index to be populated
+        time.sleep(5)  # allow for index to be populated
         query_result = route_layer(text="Hello", route_filter=["Route 1"]).name
 
         try:

--- a/tests/unit/test_layer.py
+++ b/tests/unit/test_layer.py
@@ -289,7 +289,7 @@ class TestRouteLayer:
             route_layer(text="Hello", route_filter=["Route 8"]).name
         except ValueError:
             assert True
-        
+
         # delete index
         pineconeindex.delete_index()
 

--- a/tests/unit/test_layer.py
+++ b/tests/unit/test_layer.py
@@ -280,7 +280,7 @@ class TestRouteLayer:
         route_layer = RouteLayer(
             encoder=openai_encoder, routes=routes, index=pineconeindex
         )
-        time.sleep(5)  # allow for index to be populated
+        time.sleep(10)  # allow for index to be populated
         query_result = route_layer(text="Hello", route_filter=["Route 1"]).name
 
         try:
@@ -299,7 +299,7 @@ class TestRouteLayer:
         route_layer = RouteLayer(
             encoder=openai_encoder, routes=routes, index=pineconeindex
         )
-        time.sleep(5)  # allow for index to be populated
+        time.sleep(10)  # allow for index to be populated
         query_result = route_layer(text="Hello", route_filter=["Route 1"]).name
 
         try:

--- a/tests/unit/test_layer.py
+++ b/tests/unit/test_layer.py
@@ -280,13 +280,16 @@ class TestRouteLayer:
         route_layer = RouteLayer(
             encoder=openai_encoder, routes=routes, index=pineconeindex
         )
-        time.sleep(5)  # allow for index to be populated
+        time.sleep(10)  # allow for index to be populated
         query_result = route_layer(text="Hello", route_filter=["Route 1"]).name
 
         try:
             route_layer(text="Hello", route_filter=["Route 8"]).name
         except ValueError:
             assert True
+
+        # delete index
+        pineconeindex.delete_index()
 
         assert query_result in ["Route 1"]
 
@@ -296,13 +299,16 @@ class TestRouteLayer:
         route_layer = RouteLayer(
             encoder=openai_encoder, routes=routes, index=pineconeindex
         )
-        time.sleep(5)  # allow for index to be populated
+        time.sleep(10)  # allow for index to be populated
         query_result = route_layer(text="Hello", route_filter=["Route 1"]).name
 
         try:
             route_layer(text="Hello", route_filter=["Route 8"]).name
         except ValueError:
             assert True
+
+        # delete index
+        pineconeindex.delete_index()
 
         assert query_result in ["Route 1"]
 

--- a/tests/unit/test_layer.py
+++ b/tests/unit/test_layer.py
@@ -281,9 +281,7 @@ class TestRouteLayer:
             encoder=openai_encoder, routes=routes, index=pineconeindex
         )
         time.sleep(5)  # allow for index to be populated
-        print(routes)
         query_result = route_layer(text="Hello", route_filter=["Route 1"]).name
-        print(query_result)
 
         try:
             route_layer(text="Hello", route_filter=["Route 8"]).name


### PR DESCRIPTION
fix: BadRequestError: Error code: 400 - {'error': {'message': "'$.input' is invalid. Please check the API reference: https://platform.openai.com/docs/api-reference.", 'type': 'invalid_request_error', 'param': None, 'code': None}}
 
 Occurs when _encode_documents attempts to run splitter(docs), and len(docs)>2048, as it's an OpenAI limit when generating embeddings of an array.

 How it fixes the problem:
 Split the array into multiple arrays when len(docs)>2000, and sends the multiple arrays to generate the embeddings.