### PR TITLE
fix: video splitter -> type error

### DIFF
--- a/docs/00-introduction.ipynb
+++ b/docs/00-introduction.ipynb
@@ -65,7 +65,16 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "d:\\Program_Installation\\anaconda\\envs\\rag\\Lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "from semantic_router import Route\n",
     "\n",
@@ -146,14 +155,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2024-04-19 18:34:06 INFO semantic_router.utils.logger local\u001b[0m\n"
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger local\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 1 length: 34\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 1 trunc length: 34\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 2 length: 51\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 2 trunc length: 51\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 3 length: 33\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 3 trunc length: 33\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 4 length: 33\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 4 trunc length: 33\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 5 length: 38\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 5 trunc length: 38\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 6 length: 27\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 6 trunc length: 27\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 7 length: 24\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 7 trunc length: 24\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 8 length: 21\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 8 trunc length: 21\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 9 length: 20\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 9 trunc length: 20\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 10 length: 25\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 10 trunc length: 25\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 11 length: 22\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 11 trunc length: 22\u001b[0m\n"
      ]
     }
    ],
@@ -172,16 +203,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2024-05-02 12:09:35 INFO semantic_router.utils.logger Document 1 length: 24\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:35 INFO semantic_router.utils.logger Document 1 trunc length: 24\u001b[0m\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "RouteChoice(name='politics', function_call=None, similarity_score=None)"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -192,16 +231,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2024-05-02 12:09:37 INFO semantic_router.utils.logger Document 1 length: 24\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:37 INFO semantic_router.utils.logger Document 1 trunc length: 24\u001b[0m\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "RouteChoice(name='chitchat', function_call=None, similarity_score=None)"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -219,16 +266,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2024-05-02 12:09:38 INFO semantic_router.utils.logger Document 1 length: 40\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:38 INFO semantic_router.utils.logger Document 1 trunc length: 40\u001b[0m\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "RouteChoice(name=None, function_call=None, similarity_score=None)"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -246,9 +301,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2024-05-02 12:09:40 INFO semantic_router.utils.logger Document 1 length: 35\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:40 INFO semantic_router.utils.logger Document 1 trunc length: 35\u001b[0m\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
@@ -256,7 +319,7 @@
        " RouteChoice(name='chitchat', function_call=None, similarity_score=0.8356239688161808)]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -267,16 +330,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2024-05-02 12:09:42 INFO semantic_router.utils.logger Document 1 length: 40\u001b[0m\n",
+      "\u001b[32m2024-05-02 12:09:42 INFO semantic_router.utils.logger Document 1 trunc length: 40\u001b[0m\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "[]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -309,7 +380,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/docs/00-introduction.ipynb
+++ b/docs/00-introduction.ipynb
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,36 +155,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger local\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 1 length: 34\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 1 trunc length: 34\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 2 length: 51\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 2 trunc length: 51\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 3 length: 33\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 3 trunc length: 33\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 4 length: 33\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 4 trunc length: 33\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 5 length: 38\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 5 trunc length: 38\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 6 length: 27\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 6 trunc length: 27\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 7 length: 24\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 7 trunc length: 24\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 8 length: 21\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 8 trunc length: 21\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 9 length: 20\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 9 trunc length: 20\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 10 length: 25\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 10 trunc length: 25\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 11 length: 22\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:30 INFO semantic_router.utils.logger Document 11 trunc length: 22\u001b[0m\n"
+      "\u001b[32m2024-05-02 12:38:34 INFO semantic_router.utils.logger local\u001b[0m\n"
      ]
     }
    ],
@@ -203,24 +181,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2024-05-02 12:09:35 INFO semantic_router.utils.logger Document 1 length: 24\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:35 INFO semantic_router.utils.logger Document 1 trunc length: 24\u001b[0m\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
        "RouteChoice(name='politics', function_call=None, similarity_score=None)"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -231,24 +201,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2024-05-02 12:09:37 INFO semantic_router.utils.logger Document 1 length: 24\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:37 INFO semantic_router.utils.logger Document 1 trunc length: 24\u001b[0m\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
        "RouteChoice(name='chitchat', function_call=None, similarity_score=None)"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -266,24 +228,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2024-05-02 12:09:38 INFO semantic_router.utils.logger Document 1 length: 40\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:38 INFO semantic_router.utils.logger Document 1 trunc length: 40\u001b[0m\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
        "RouteChoice(name=None, function_call=None, similarity_score=None)"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -301,17 +255,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2024-05-02 12:09:40 INFO semantic_router.utils.logger Document 1 length: 35\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:40 INFO semantic_router.utils.logger Document 1 trunc length: 35\u001b[0m\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
@@ -319,7 +265,7 @@
        " RouteChoice(name='chitchat', function_call=None, similarity_score=0.8356239688161808)]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -330,24 +276,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2024-05-02 12:09:42 INFO semantic_router.utils.logger Document 1 length: 40\u001b[0m\n",
-      "\u001b[32m2024-05-02 12:09:42 INFO semantic_router.utils.logger Document 1 trunc length: 40\u001b[0m\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
        "[]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/semantic_router/encoders/openai.py
+++ b/semantic_router/encoders/openai.py
@@ -81,7 +81,6 @@ class OpenAIEncoder(BaseEncoder):
             # check if any document exceeds token limit and truncate if so
             for i in range(len(docs)):
                 docs[i] = self._truncate(docs[i])
-                # logger.info(f"Document {i+1} trunc length: {len(docs[i])}")
 
         # Exponential backoff
         for j in range(1, 7):

--- a/semantic_router/encoders/openai.py
+++ b/semantic_router/encoders/openai.py
@@ -80,9 +80,9 @@ class OpenAIEncoder(BaseEncoder):
         if truncate:
             # check if any document exceeds token limit and truncate if so
             for i in range(len(docs)):
-                logger.info(f"Document {i+1} length: {len(docs[i])}")
+                # logger.info(f"Document {i+1} length: {len(docs[i])}")
                 docs[i] = self._truncate(docs[i])
-                logger.info(f"Document {i+1} trunc length: {len(docs[i])}")
+                # logger.info(f"Document {i+1} trunc length: {len(docs[i])}")
 
         # Exponential backoff
         for j in range(1, 7):

--- a/semantic_router/encoders/openai.py
+++ b/semantic_router/encoders/openai.py
@@ -80,7 +80,6 @@ class OpenAIEncoder(BaseEncoder):
         if truncate:
             # check if any document exceeds token limit and truncate if so
             for i in range(len(docs)):
-                # logger.info(f"Document {i+1} length: {len(docs[i])}")
                 docs[i] = self._truncate(docs[i])
                 # logger.info(f"Document {i+1} trunc length: {len(docs[i])}")
 

--- a/semantic_router/schema.py
+++ b/semantic_router/schema.py
@@ -1,6 +1,5 @@
 from enum import Enum
-from typing import List, Optional
-
+from typing import List, Optional, Union, Any
 from pydantic.v1 import BaseModel
 
 
@@ -52,7 +51,7 @@ class Message(BaseModel):
 
 
 class DocumentSplit(BaseModel):
-    docs: List[str]
+    docs: List[Union[str, Any]]
     is_triggered: bool = False
     triggered_score: Optional[float] = None
     token_count: Optional[int] = None
@@ -60,7 +59,7 @@ class DocumentSplit(BaseModel):
 
     @property
     def content(self) -> str:
-        return " ".join(self.docs)
+        return " ".join([doc if isinstance(doc, str) else "" for doc in self.docs])
 
 
 class Metric(Enum):


### PR DESCRIPTION
## **User description**
Encountered an issue with consecutive similarity functionality due to variations in file types, specifically observed with non-string data types. This pull request addresses the problem by implementing support for dynamic data types, ensuring compatibility beyond just strings.


___

## **Type**
Bug fix, Enhancement


___

## **Description**
- Enhanced `DocumentSplit` model in `semantic_router/schema.py` to support lists containing various data types, not just strings.
- Updated `content` property method to handle non-string list elements gracefully by converting them to empty strings during concatenation.
- Modified Jupyter Notebook `docs/00-introduction.ipynb` to reflect new logging outputs and updated execution counts.
- Added error outputs in the notebook regarding tqdm and IPython version warnings.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.py</strong><dd><code>Support Dynamic Data Types in DocumentSplit Model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/schema.py
<li>Added support for dynamic data types in <code>DocumentSplit</code> model by <br>allowing <code>docs</code> to be a list of either strings or any type.<br> <li> Modified the <code>content</code> property to handle non-string types by converting <br>them to empty strings in the join operation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/266/files#diff-2745f608339614a7c34abdc5917e375f87cb4c953a07404ed96f4f37180b3232">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>00-introduction.ipynb</strong><dd><code>Update Notebook Outputs and Execution Details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/00-introduction.ipynb
<li>Updated output cells to include new logging information about document <br>lengths and truncations.<br> <li> Adjusted execution counts and added error outputs related to tqdm and <br>IPython version warnings.<br>


</details>
    

  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/266/files#diff-21491e5b61c76430cdaa72c7efd5fe297e3128ea10845545e116fe59ff0e4056">+85/-14</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

