### PR TITLE
fix: add namespace to get all for pinecone

### DIFF
--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -188,6 +188,8 @@ class PineconeIndex(BaseIndex):
         # Construct the request URL for listing vectors. Adjust parameters as needed.
         list_url = f"https://{self.host}/vectors/list{prefix_str}"
         params: Dict = {}
+        if self.namespace:
+            params["namespace"] = self.namespace
         headers = {"Api-Key": os.environ["PINECONE_API_KEY"]}
         metadata = []
 


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- The PR adds a condition to include the `namespace` in the request parameters for the `_get_all` method in the Pinecone router. This ensures that the namespace is considered when fetching all vectors.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pinecone.py</strong><dd><code>Include Namespace in API Request Parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/index/pinecone.py
<li>Added a condition to include <code>namespace</code> in the request parameters if it <br>is set.


</details>
    

  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/270/files#diff-c57f54339773ad317ee6eafd071395202933f9eeaf59a10c28fc22d06bf564a2">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

