### PR TITLE
fix: typo in base.py

### DIFF
--- a/semantic_router/llms/base.py
+++ b/semantic_router/llms/base.py
@@ -91,7 +91,7 @@ Return only JSON, stating the argument names and their corresponding values.
 	=== EXAMPLE_OUTPUT End ===
 ### EXAMPLE End ###
 
-Note: I will tip $500 for and accurate JSON output. You will be penalized for an inaccurate JSON output.
+Note: I will tip $500 for nd accurate JSON output. You will be penalized for an inaccurate JSON output.
 
 Provide JSON output now:
 """


### PR DESCRIPTION
Typo in base.py