### PR TITLE
fix: Use 'api_key' parameter if passed explicitly

### DIFF
--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -71,7 +71,7 @@ class PineconeIndex(BaseIndex):
         self.namespace = namespace
         self.type = "pinecone"
         self.api_key = api_key or os.getenv("PINECONE_API_KEY")
-        
+
         if self.api_key is None:
             raise ValueError("Pinecone API key is required.")
 

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -38,6 +38,7 @@ class PineconeRecord(BaseModel):
 
 class PineconeIndex(BaseIndex):
     index_prefix: str = "semantic-router--"
+    api_key: Optional[str] = None
     index_name: str = "index"
     dimensions: Union[int, None] = None
     metric: str = "cosine"
@@ -69,7 +70,12 @@ class PineconeIndex(BaseIndex):
         self.host = host
         self.namespace = namespace
         self.type = "pinecone"
-        self.client = self._initialize_client(api_key=api_key)
+        self.api_key = api_key or os.getenv("PINECONE_API_KEY")
+        
+        if self.api_key is None:
+            raise ValueError("Pinecone API key is required.")
+
+        self.client = self._initialize_client(api_key=self.api_key)
 
     def _initialize_client(self, api_key: Optional[str] = None):
         try:
@@ -82,9 +88,6 @@ class PineconeIndex(BaseIndex):
                 "You can install it with: "
                 "`pip install 'semantic-router[pinecone]'`"
             )
-        api_key = api_key or os.getenv("PINECONE_API_KEY")
-        if api_key is None:
-            raise ValueError("Pinecone API key is required.")
         pinecone_args = {"api_key": api_key, "source_tag": "semantic-router"}
         if self.namespace:
             pinecone_args["namespace"] = self.namespace
@@ -190,7 +193,7 @@ class PineconeIndex(BaseIndex):
         params: Dict = {}
         if self.namespace:
             params["namespace"] = self.namespace
-        headers = {"Api-Key": os.environ["PINECONE_API_KEY"]}
+        headers = {"Api-Key": self.api_key}
         metadata = []
 
         while True:


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Introduced an instance attribute `api_key` in `PineconeIndex` to handle API keys more effectively.
- Constructor now sets `api_key` with a direct assignment, allowing explicit passing of the key, and falls back to the environment variable if not provided.
- Added error handling to raise a `ValueError` if `api_key` is not set, ensuring the API key's presence is validated during object initialization.
- Refactored the `_get_all` method to utilize the instance's `api_key`, improving security by avoiding direct environment variable access.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pinecone.py</strong><dd><code>Enhance API Key Management in PineconeIndex Class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/index/pinecone.py
<li>Added an <code>api_key</code> attribute to the <code>PineconeIndex</code> class.<br> <li> Modified the constructor to prioritize the passed <code>api_key</code> over the <br>environment variable.<br> <li> Added a check to raise an exception if <code>api_key</code> is not provided.<br> <li> Updated the <code>_get_all</code> method to use the instance's <code>api_key</code> instead of <br>directly accessing the environment variable.<br>


</details>
    

  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/278/files#diff-c57f54339773ad317ee6eafd071395202933f9eeaf59a10c28fc22d06bf564a2">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

