### PR TITLE
Fixes #284 Update 03-basic-langchain-agent.ipynb

### DIFF
--- a/docs/03-basic-langchain-agent.ipynb
+++ b/docs/03-basic-langchain-agent.ipynb
@@ -431,7 +431,7 @@
    ],
    "source": [
     "from langchain.agents import AgentType, initialize_agent\n",
-    "from langchain.chat_models import ChatOpenAI\n",
+    "from langchain_openai import ChatOpenAI\n",
     "from langchain.memory import ConversationBufferWindowMemory\n",
     "\n",
     "llm = ChatOpenAI(model=\"gpt-3.5-turbo-1106\")\n",


### PR DESCRIPTION
Changed:

```python
from langchain.agents import AgentType, initialize_agent
from langchain.chat_models import ChatOpenAI
from langchain.memory import ConversationBufferWindowMemory

llm = ChatOpenAI(model="gpt-3.5-turbo-1106")
```

To

```python
from langchain.agents import AgentType, initialize_agent
from langchain_openai import ChatOpenAI
from langchain.memory import ConversationBufferWindowMemory

llm = ChatOpenAI(model="gpt-3.5-turbo-1106")
```
