### PR TITLE
fix: update tests

### DIFF
--- a/tests/unit/encoders/test_clip.py
+++ b/tests/unit/encoders/test_clip.py
@@ -34,14 +34,20 @@ def misshaped_pil_image():
 
 
 class TestClipEncoder:
-    def test_clip_encoder__import_errors_transformers(self, mocker):
+    @pytest.mark.skipif(
+        os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
+    )
+    def test_clip_encoder__import_errors_transformers(self):
         with patch.dict("sys.modules", {"transformers": None}):
             with pytest.raises(ImportError) as error:
                 CLIPEncoder()
 
         assert "install transformers" in str(error.value)
 
-    def test_clip_encoder__import_errors_torch(self, mocker):
+    @pytest.mark.skipif(
+        os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
+    )
+    def test_clip_encoder__import_errors_torch(self):
         with patch.dict("sys.modules", {"torch": None}):
             with pytest.raises(ImportError) as error:
                 CLIPEncoder()

--- a/tests/unit/encoders/test_clip.py
+++ b/tests/unit/encoders/test_clip.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 import torch
 from PIL import Image
+from unittest.mock import patch
 
 from semantic_router.encoders import CLIPEncoder
 
@@ -32,16 +33,20 @@ def misshaped_pil_image():
     return Image.fromarray(np.random.rand(64, 64, 3).astype(np.uint8))
 
 
-class TestVitEncoder:
+class TestClipEncoder:
     def test_clip_encoder__import_errors_transformers(self, mocker):
-        mocker.patch.dict("sys.modules", {"transformers": None})
-        with pytest.raises(ImportError):
-            CLIPEncoder()
+        with patch.dict("sys.modules", {"transformers": None}):
+            with pytest.raises(ImportError) as error:
+                CLIPEncoder()
+        
+        assert "install transformers" in str(error.value)
 
     def test_clip_encoder__import_errors_torch(self, mocker):
-        mocker.patch.dict("sys.modules", {"torch": None})
-        with pytest.raises(ImportError):
-            CLIPEncoder()
+        with patch.dict("sys.modules", {"torch": None}):
+            with pytest.raises(ImportError) as error:
+                CLIPEncoder()
+
+        assert "install Pytorch" in str(error.value)
 
     @pytest.mark.skipif(
         os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"

--- a/tests/unit/encoders/test_clip.py
+++ b/tests/unit/encoders/test_clip.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import pytest
 import torch
@@ -6,7 +7,6 @@ from PIL import Image
 from semantic_router.encoders import CLIPEncoder
 
 test_model_name = "aurelio-ai/sr-test-clip"
-clip_encoder = CLIPEncoder(name=test_model_name)
 embed_dim = 64
 
 if torch.cuda.is_available():
@@ -43,35 +43,59 @@ class TestVitEncoder:
         with pytest.raises(ImportError):
             CLIPEncoder()
 
+    @pytest.mark.skipif(
+        os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
+    )
     def test_clip_encoder_initialization(self):
+        clip_encoder = CLIPEncoder(name=test_model_name)
         assert clip_encoder.name == test_model_name
         assert clip_encoder.type == "huggingface"
         assert clip_encoder.score_threshold == 0.2
         assert clip_encoder.device == device
 
+    @pytest.mark.skipif(
+        os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
+    )
     def test_clip_encoder_call_text(self):
+        clip_encoder = CLIPEncoder(name=test_model_name)
         embeddings = clip_encoder(["hello", "world"])
 
         assert len(embeddings) == 2
         assert len(embeddings[0]) == embed_dim
 
+    @pytest.mark.skipif(
+        os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
+    )
     def test_clip_encoder_call_image(self, dummy_pil_image):
+        clip_encoder = CLIPEncoder(name=test_model_name)
         encoded_images = clip_encoder([dummy_pil_image] * 3)
 
         assert len(encoded_images) == 3
         assert set(map(len, encoded_images)) == {embed_dim}
 
+    @pytest.mark.skipif(
+        os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
+    )
     def test_clip_encoder_call_misshaped(self, dummy_pil_image, misshaped_pil_image):
+        clip_encoder = CLIPEncoder(name=test_model_name)
         encoded_images = clip_encoder([dummy_pil_image, misshaped_pil_image])
 
         assert len(encoded_images) == 2
         assert set(map(len, encoded_images)) == {embed_dim}
 
+    @pytest.mark.skipif(
+        os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
+    )
     def test_clip_device(self):
+        clip_encoder = CLIPEncoder(name=test_model_name)
         device = clip_encoder._model.device.type
         assert device == device
 
+    @pytest.mark.skipif(
+        os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
+    )
     def test_clip_encoder_ensure_rgb(self, dummy_black_and_white_img):
+        clip_encoder = CLIPEncoder(name=test_model_name)
         rgb_image = clip_encoder._ensure_rgb(dummy_black_and_white_img)
 
         assert rgb_image.mode == "RGB"

--- a/tests/unit/encoders/test_clip.py
+++ b/tests/unit/encoders/test_clip.py
@@ -38,7 +38,7 @@ class TestClipEncoder:
         with patch.dict("sys.modules", {"transformers": None}):
             with pytest.raises(ImportError) as error:
                 CLIPEncoder()
-        
+
         assert "install transformers" in str(error.value)
 
     def test_clip_encoder__import_errors_torch(self, mocker):

--- a/tests/unit/encoders/test_huggingface.py
+++ b/tests/unit/encoders/test_huggingface.py
@@ -1,12 +1,12 @@
 from unittest.mock import patch
 
+import os
 import numpy as np
 import pytest
 
 from semantic_router.encoders.huggingface import HuggingFaceEncoder
 
 test_model_name = "aurelio-ai/sr-test-huggingface"
-encoder = HuggingFaceEncoder(name=test_model_name)
 
 
 class TestHuggingFaceEncoder:
@@ -26,7 +26,11 @@ class TestHuggingFaceEncoder:
 
         assert "Please install Pytorch to use HuggingFaceEncoder" in str(error.value)
 
+    @pytest.mark.skipif(
+        os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
+    )
     def test_huggingface_encoder_mean_pooling(self):
+        encoder = HuggingFaceEncoder(name=test_model_name)
         test_docs = ["This is a test", "This is another test"]
         embeddings = encoder(test_docs, pooling_strategy="mean")
         assert isinstance(embeddings, list)
@@ -34,7 +38,11 @@ class TestHuggingFaceEncoder:
         assert all(isinstance(embedding, list) for embedding in embeddings)
         assert all(len(embedding) > 0 for embedding in embeddings)
 
+    @pytest.mark.skipif(
+        os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
+    )
     def test_huggingface_encoder_max_pooling(self):
+        encoder = HuggingFaceEncoder(name=test_model_name)
         test_docs = ["This is a test", "This is another test"]
         embeddings = encoder(test_docs, pooling_strategy="max")
         assert isinstance(embeddings, list)
@@ -42,7 +50,11 @@ class TestHuggingFaceEncoder:
         assert all(isinstance(embedding, list) for embedding in embeddings)
         assert all(len(embedding) > 0 for embedding in embeddings)
 
+    @pytest.mark.skipif(
+        os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
+    )
     def test_huggingface_encoder_normalized_embeddings(self):
+        encoder = HuggingFaceEncoder(name=test_model_name)
         docs = ["This is a test document.", "Another test document."]
         unnormalized_embeddings = encoder(docs, normalize_embeddings=False)
         normalized_embeddings = encoder(docs, normalize_embeddings=True)

--- a/tests/unit/test_layer.py
+++ b/tests/unit/test_layer.py
@@ -276,6 +276,9 @@ class TestRouteLayer:
 
         assert query_result in ["Route 1"]
 
+    @pytest.mark.skipif(
+        os.environ.get("PINECONE_API_KEY") is None, reason="Pinecone API key required"
+    )
     def test_query_filter_pinecone(self, openai_encoder, routes, index_cls):
         pinecone_api_key = os.environ["PINECONE_API_KEY"]
         pineconeindex = PineconeIndex(api_key=pinecone_api_key)
@@ -292,6 +295,9 @@ class TestRouteLayer:
 
         assert query_result in ["Route 1"]
 
+    @pytest.mark.skipif(
+        os.environ.get("PINECONE_API_KEY") is None, reason="Pinecone API key required"
+    )
     def test_namespace_pinecone_index(self, openai_encoder, routes, index_cls):
         pinecone_api_key = os.environ["PINECONE_API_KEY"]
         pineconeindex = PineconeIndex(api_key=pinecone_api_key, namespace="test")


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Added `pytest.mark.skipif` to conditionally skip tests in `test_clip.py` based on the `RUN_HF_TESTS` environment variable.
- Added `pytest.mark.skipif` to conditionally skip tests in `test_huggingface.py` based on the `RUN_HF_TESTS` environment variable.
- Added `pytest.mark.skipif` to conditionally skip Pinecone-related tests in `test_layer.py` based on the `PINECONE_API_KEY` environment variable.
- Moved encoder initialization inside test functions to ensure proper setup.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_clip.py</strong><dd><code>Add conditional skipping for CLIP encoder tests based on environment </code><br><code>variable.</code></dd></summary>
<hr>

tests/unit/encoders/test_clip.py
<li>Added <code>os</code> import for environment variable checks.<br> <li> Introduced <code>pytest.mark.skipif</code> to conditionally skip tests based on <br><code>RUN_HF_TESTS</code> environment variable.<br> <li> Moved <code>clip_encoder</code> initialization inside each test function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/318/files#diff-d547317e7c1a48e02dfb53fbe20e8d6ddc81b8e7683d33ed018a6acb022ba32b">+25/-1</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_huggingface.py</strong><dd><code>Add conditional skipping for HuggingFace encoder tests based on </code><br><code>environment variable.</code></dd></summary>
<hr>

tests/unit/encoders/test_huggingface.py
<li>Added <code>os</code> import for environment variable checks.<br> <li> Introduced <code>pytest.mark.skipif</code> to conditionally skip tests based on <br><code>RUN_HF_TESTS</code> environment variable.<br> <li> Moved <code>encoder</code> initialization inside each test function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/318/files#diff-2ed7f4a1bd4815470f569a6ae1b2d0bc63a01c538cefd604decf602e9feb379e">+13/-1</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_layer.py</strong><dd><code>Add conditional skipping for Pinecone-related tests based on API key.</code></dd></summary>
<hr>

tests/unit/test_layer.py
<li>Introduced <code>pytest.mark.skipif</code> to conditionally skip Pinecone-related <br>tests based on <code>PINECONE_API_KEY</code> environment variable.<br>


</details>
    

  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/318/files#diff-e26dd7614ce8382ff549d73b577ee409ef477088b37856b64b02411ba3cad4f5">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

