### PR TITLE
fix: add skip to vit

### DIFF
--- a/tests/unit/encoders/test_vit.py
+++ b/tests/unit/encoders/test_vit.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import pytest
 import torch
@@ -48,29 +49,44 @@ class TestVitEncoder:
         with pytest.raises(ImportError):
             VitEncoder()
 
+    @pytest.mark.skipif(
+        os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
+    )
     def test_vit_encoder_initialization(self):
         assert vit_encoder.name == test_model_name
         assert vit_encoder.type == "huggingface"
         assert vit_encoder.score_threshold == 0.5
         assert vit_encoder.device == device
 
+    @pytest.mark.skipif(
+        os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
+    )
     def test_vit_encoder_call(self, dummy_pil_image):
         encoded_images = vit_encoder([dummy_pil_image] * 3)
 
         assert len(encoded_images) == 3
         assert set(map(len, encoded_images)) == {embed_dim}
 
+    @pytest.mark.skipif(
+        os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
+    )
     def test_vit_encoder_call_misshaped(self, dummy_pil_image, misshaped_pil_image):
         encoded_images = vit_encoder([dummy_pil_image, misshaped_pil_image])
 
         assert len(encoded_images) == 2
         assert set(map(len, encoded_images)) == {embed_dim}
 
+    @pytest.mark.skipif(
+        os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
+    )
     def test_vit_encoder_process_images_device(self, dummy_pil_image):
         imgs = vit_encoder._process_images([dummy_pil_image] * 3)["pixel_values"]
 
         assert imgs.device.type == device
 
+    @pytest.mark.skipif(
+        os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
+    )
     def test_vit_encoder_ensure_rgb(self, dummy_black_and_white_img):
         rgb_image = vit_encoder._ensure_rgb(dummy_black_and_white_img)
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Added `pytest.mark.skipif` decorator to multiple test functions in `test_vit.py` to conditionally skip tests based on the `RUN_HF_TESTS` environment variable.
- This change ensures that certain tests are only run when the `RUN_HF_TESTS` environment variable is set, preventing unnecessary test execution in environments where these tests are not required.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_vit.py</strong><dd><code>Add conditional skip for ViT encoder tests based on environment </code><br><code>variable</code></dd></summary>
<hr>

tests/unit/encoders/test_vit.py
<li>Added <code>os</code> import.<br> <li> Added <code>pytest.mark.skipif</code> decorator to multiple test functions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/319/files#diff-643db2a4ce125a30c224e298b5698cf92494be16efdd60a7e13e1d26e62d4c75">+16/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

