### PR TITLE
fix: add skips to pinecone openai tests

### DIFF
--- a/tests/integration/encoders/test_openai_integration.py
+++ b/tests/integration/encoders/test_openai_integration.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from semantic_router.encoders.openai import OpenAIEncoder
 
@@ -11,22 +12,37 @@ def openai_encoder():
 
 
 class TestOpenAIEncoder:
+    @pytest.mark.skipif(
+        os.environ.get("OPENAI_API_KEY") is None, reason="OpenAI API key required"
+    )
     def test_openai_encoder_init_success(self, openai_encoder):
         assert openai_encoder.client is not None
 
+    @pytest.mark.skipif(
+        os.environ.get("OPENAI_API_KEY") is None, reason="OpenAI API key required"
+    )
     def test_openai_encoder_dims(self, openai_encoder):
         embeddings = openai_encoder(["test document"])
         assert len(embeddings) == 1
         assert len(embeddings[0]) == 1536
 
+    @pytest.mark.skipif(
+        os.environ.get("OPENAI_API_KEY") is None, reason="OpenAI API key required"
+    )
     def test_openai_encoder_call_truncation(self, openai_encoder):
         openai_encoder([long_doc])
 
+    @pytest.mark.skipif(
+        os.environ.get("OPENAI_API_KEY") is None, reason="OpenAI API key required"
+    )
     def test_openai_encoder_call_no_truncation(self, openai_encoder):
         with pytest.raises(ValueError) as _:
             # default truncation is True
             openai_encoder([long_doc], truncate=False)
 
+    @pytest.mark.skipif(
+        os.environ.get("OPENAI_API_KEY") is None, reason="OpenAI API key required"
+    )
     def test_openai_encoder_call_uninitialized_client(self, openai_encoder):
         # Set the client to None to simulate an uninitialized client
         openai_encoder.client = None

--- a/tests/unit/test_layer.py
+++ b/tests/unit/test_layer.py
@@ -280,39 +280,41 @@ class TestRouteLayer:
         os.environ.get("PINECONE_API_KEY") is None, reason="Pinecone API key required"
     )
     def test_query_filter_pinecone(self, openai_encoder, routes, index_cls):
-        pinecone_api_key = os.environ["PINECONE_API_KEY"]
-        pineconeindex = PineconeIndex(api_key=pinecone_api_key)
-        route_layer = RouteLayer(
-            encoder=openai_encoder, routes=routes, index=pineconeindex
-        )
-        time.sleep(10)  # allow for index to be populated
-        query_result = route_layer(text="Hello", route_filter=["Route 1"]).name
+        if type(index_cls) == PineconeIndex:
+            pinecone_api_key = os.environ["PINECONE_API_KEY"]
+            pineconeindex = PineconeIndex(api_key=pinecone_api_key)
+            route_layer = RouteLayer(
+                encoder=openai_encoder, routes=routes, index=pineconeindex
+            )
+            time.sleep(10)  # allow for index to be populated
+            query_result = route_layer(text="Hello", route_filter=["Route 1"]).name
 
-        try:
-            route_layer(text="Hello", route_filter=["Route 8"]).name
-        except ValueError:
-            assert True
+            try:
+                route_layer(text="Hello", route_filter=["Route 8"]).name
+            except ValueError:
+                assert True
 
-        assert query_result in ["Route 1"]
+            assert query_result in ["Route 1"]
 
     @pytest.mark.skipif(
         os.environ.get("PINECONE_API_KEY") is None, reason="Pinecone API key required"
     )
     def test_namespace_pinecone_index(self, openai_encoder, routes, index_cls):
-        pinecone_api_key = os.environ["PINECONE_API_KEY"]
-        pineconeindex = PineconeIndex(api_key=pinecone_api_key, namespace="test")
-        route_layer = RouteLayer(
-            encoder=openai_encoder, routes=routes, index=pineconeindex
-        )
-        time.sleep(10)  # allow for index to be populated
-        query_result = route_layer(text="Hello", route_filter=["Route 1"]).name
+        if type(index_cls) == PineconeIndex:
+            pinecone_api_key = os.environ["PINECONE_API_KEY"]
+            pineconeindex = PineconeIndex(api_key=pinecone_api_key, namespace="test")
+            route_layer = RouteLayer(
+                encoder=openai_encoder, routes=routes, index=pineconeindex
+            )
+            time.sleep(10)  # allow for index to be populated
+            query_result = route_layer(text="Hello", route_filter=["Route 1"]).name
 
-        try:
-            route_layer(text="Hello", route_filter=["Route 8"]).name
-        except ValueError:
-            assert True
+            try:
+                route_layer(text="Hello", route_filter=["Route 8"]).name
+            except ValueError:
+                assert True
 
-        assert query_result in ["Route 1"]
+            assert query_result in ["Route 1"]
 
     def test_query_with_no_index(self, openai_encoder, index_cls):
         route_layer = RouteLayer(encoder=openai_encoder, index=index_cls())


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Added `pytest.mark.skipif` decorators to skip OpenAI encoder tests if `OPENAI_API_KEY` is not set.
- Added conditional checks to Pinecone tests to ensure they only run if `PINECONE_API_KEY` is set.
- Modified test logic in Pinecone tests to handle cases where the index class is not Pinecone.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_openai_integration.py</strong><dd><code>Add skips to OpenAI encoder tests based on API key presence</code></dd></summary>
<hr>

tests/integration/encoders/test_openai_integration.py
<li>Added <code>pytest.mark.skipif</code> decorators to skip tests if <code>OPENAI_API_KEY</code> is <br>not set.<br> <li> Ensured all relevant tests check for the presence of the OpenAI API <br>key.<br>


</details>
    

  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/328/files#diff-fcf9fdb076a42d51d319927136eb07852a0bb01b2ed1f76e67dd73ddf9b15431">+16/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_layer.py</strong><dd><code>Add skips and conditional checks for Pinecone tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_layer.py
<li>Added conditional checks to ensure Pinecone-specific tests only run if <br><code>PINECONE_API_KEY</code> is set.<br> <li> Modified test logic to handle cases where the index class is not <br>Pinecone.<br>


</details>
    

  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/328/files#diff-e26dd7614ce8382ff549d73b577ee409ef477088b37856b64b02411ba3cad4f5">+26/-24</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

