### PR TITLE
fix: more permissive deletes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "semantic-router"
-version = "0.0.47"
+version = "0.0.48"
 description = "Super fast semantic router for AI decision making"
 authors = [
     "James Briggs <james@aurelio.ai>",

--- a/semantic_router/layer.py
+++ b/semantic_router/layer.py
@@ -433,9 +433,9 @@ class RouteLayer:
         :type str:
         """
         if route_name not in [route.name for route in self.routes]:
-            err_msg = f"Route `{route_name}` not found"
-            logger.error(err_msg)
-            raise ValueError(err_msg)
+            err_msg = f"Route `{route_name}` not found in RouteLayer"
+            logger.warning(err_msg)
+            self.index.delete(route_name=route_name)
         else:
             self.routes = [route for route in self.routes if route.name != route_name]
             self.index.delete(route_name=route_name)

--- a/tests/unit/test_layer.py
+++ b/tests/unit/test_layer.py
@@ -244,11 +244,8 @@ class TestRouteLayer:
         )
         # Attempt to remove a route that does not exist
         non_existent_route = "non-existent-route"
-        with pytest.raises(ValueError) as excinfo:
-            route_layer.delete(non_existent_route)
-        assert (
-            str(excinfo.value) == f"Route `{non_existent_route}` not found"
-        ), "Attempting to remove a non-existent route should raise a ValueError."
+        route_layer.delete(non_existent_route)
+        # we should see warning in logs only (ie no errors)
 
     def test_add_multiple_routes(self, openai_encoder, routes, index_cls):
         route_layer = RouteLayer(encoder=openai_encoder, index=index_cls())


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Modified the `delete` method in `semantic_router/layer.py` to handle non-existent routes more permissively by logging a warning instead of raising a `ValueError` and ensuring the index is updated.
- Updated the project version in `pyproject.toml` from `0.0.47` to `0.0.48`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layer.py</strong><dd><code>Modify route deletion logic to be more permissive</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/layer.py
<li>Changed error handling for non-existent routes in the <code>delete</code> method.<br> <li> Replaced <code>ValueError</code> with a warning log and an index delete operation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/333/files#diff-e495ddf91e18dd7477eb129fd2c0ab7dfbaf2440534c28b6156a76acdaf51433">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Bump version to 0.0.48</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml
- Updated the version from `0.0.47` to `0.0.48`.



</details>
    

  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/333/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

