### PR TITLE
feat: add sync setting parameter to index

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "semantic-router"
-version = "0.0.50"
+version = "0.0.51"
 description = "Super fast semantic router for AI decision making"
 authors = [
     "James Briggs <james@aurelio.ai>",

--- a/semantic_router/index/base.py
+++ b/semantic_router/index/base.py
@@ -18,17 +18,28 @@ class BaseIndex(BaseModel):
     utterances: Optional[np.ndarray] = None
     dimensions: Union[int, None] = None
     type: str = "base"
-    sync: str = "merge-force-local"
+    sync: Union[str, None] = None
 
     def add(
         self,
         embeddings: List[List[float]],
         routes: List[str],
         utterances: List[Any],
-        sync: bool = False,
     ):
         """
         Add embeddings to the index.
+        This method should be implemented by subclasses.
+        """
+        raise NotImplementedError("This method should be implemented by subclasses.")
+
+    def _add_and_sync(
+        self,
+        embeddings: List[List[float]],
+        routes: List[str],
+        utterances: List[Any],
+    ):
+        """
+        Add embeddings to the index and manage index syncing if necessary.
         This method should be implemented by subclasses.
         """
         raise NotImplementedError("This method should be implemented by subclasses.")

--- a/semantic_router/index/base.py
+++ b/semantic_router/index/base.py
@@ -18,6 +18,7 @@ class BaseIndex(BaseModel):
     utterances: Optional[np.ndarray] = None
     dimensions: Union[int, None] = None
     type: str = "base"
+    sync: str = "merge-force-local"
 
     def add(
         self, embeddings: List[List[float]], routes: List[str], utterances: List[Any]
@@ -70,6 +71,21 @@ class BaseIndex(BaseModel):
     def delete_index(self):
         """
         Deletes or resets the index.
+        This method should be implemented by subclasses.
+        """
+        raise NotImplementedError("This method should be implemented by subclasses.")
+    
+    def _sync_index(self, local_routes: dict):
+        """
+        Synchronize the local index with the remote index based on the specified mode.
+        Modes:
+        - "error": Raise an error if local and remote are not synchronized.
+        - "remote": Take remote as the source of truth and update local to align.
+        - "local": Take local as the source of truth and update remote to align.
+        - "merge-force-remote": Merge both local and remote taking only remote routes utterances when a route with same route name is present both locally and remotely.
+        - "merge-force-local": Merge both local and remote taking only local routes utterances when a route with same route name is present both locally and remotely.
+        - "merge": Merge both local and remote, merging also local and remote utterances when a route with same route name is present both locally and remotely.
+        
         This method should be implemented by subclasses.
         """
         raise NotImplementedError("This method should be implemented by subclasses.")

--- a/semantic_router/index/base.py
+++ b/semantic_router/index/base.py
@@ -21,7 +21,11 @@ class BaseIndex(BaseModel):
     sync: str = "merge-force-local"
 
     def add(
-        self, embeddings: List[List[float]], routes: List[str], utterances: List[Any]
+        self,
+        embeddings: List[List[float]],
+        routes: List[str],
+        utterances: List[Any],
+        sync: bool = False,
     ):
         """
         Add embeddings to the index.
@@ -74,7 +78,7 @@ class BaseIndex(BaseModel):
         This method should be implemented by subclasses.
         """
         raise NotImplementedError("This method should be implemented by subclasses.")
-    
+
     def _sync_index(self, local_routes: dict):
         """
         Synchronize the local index with the remote index based on the specified mode.
@@ -85,7 +89,7 @@ class BaseIndex(BaseModel):
         - "merge-force-remote": Merge both local and remote taking only remote routes utterances when a route with same route name is present both locally and remotely.
         - "merge-force-local": Merge both local and remote taking only local routes utterances when a route with same route name is present both locally and remotely.
         - "merge": Merge both local and remote, merging also local and remote utterances when a route with same route name is present both locally and remotely.
-        
+
         This method should be implemented by subclasses.
         """
         raise NotImplementedError("This method should be implemented by subclasses.")

--- a/semantic_router/index/local.py
+++ b/semantic_router/index/local.py
@@ -21,7 +21,11 @@ class LocalIndex(BaseIndex):
         arbitrary_types_allowed = True
 
     def add(
-        self, embeddings: List[List[float]], routes: List[str], utterances: List[str]
+        self,
+        embeddings: List[List[float]],
+        routes: List[str],
+        utterances: List[str],
+        sync: bool = False,
     ):
         embeds = np.array(embeddings)  # type: ignore
         routes_arr = np.array(routes)

--- a/semantic_router/index/local.py
+++ b/semantic_router/index/local.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from semantic_router.index.base import BaseIndex
 from semantic_router.linear import similarity_matrix, top_scores
+from semantic_router.utils.logger import logger
 
 
 class LocalIndex(BaseIndex):
@@ -25,7 +26,6 @@ class LocalIndex(BaseIndex):
         embeddings: List[List[float]],
         routes: List[str],
         utterances: List[str],
-        sync: bool = False,
     ):
         embeds = np.array(embeddings)  # type: ignore
         routes_arr = np.array(routes)
@@ -41,6 +41,16 @@ class LocalIndex(BaseIndex):
             self.index = np.concatenate([self.index, embeds])
             self.routes = np.concatenate([self.routes, routes_arr])
             self.utterances = np.concatenate([self.utterances, utterances_arr])
+
+    def _add_and_sync(
+        self,
+        embeddings: List[List[float]],
+        routes: List[str],
+        utterances: List[str],
+    ):
+        if self.sync is not None:
+            logger.warning("Sync add is not implemented for LocalIndex.")
+        self.add(embeddings, routes, utterances)
 
     def get_routes(self) -> List[Tuple]:
         """

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -65,6 +65,7 @@ class PineconeIndex(BaseIndex):
         host: str = "",
         namespace: Optional[str] = "",
         base_url: Optional[str] = "https://api.pinecone.io",
+        sync: str = "merge-force-local",
     ):
         super().__init__()
         self.index_name = index_name
@@ -77,6 +78,7 @@ class PineconeIndex(BaseIndex):
         self.type = "pinecone"
         self.api_key = api_key or os.getenv("PINECONE_API_KEY")
         self.base_url = base_url
+        self.sync = sync
 
         if self.api_key is None:
             raise ValueError("Pinecone API key is required.")
@@ -195,6 +197,57 @@ class PineconeIndex(BaseIndex):
             logger.warning("Index could not be initialized.")
         self.host = index_stats["host"] if index_stats else None
 
+    def _sync_index(self, local_routes: dict):
+        remote_routes = self.get_routes()
+        remote_dict = {route: set() for route, _ in remote_routes}
+        for route, utterance in remote_routes:
+            remote_dict[route].add(utterance)
+
+        local_dict = {route: set() for route in local_routes['routes']}
+        for route, utterance in zip(local_routes['routes'], local_routes['utterances']):
+            local_dict[route].add(utterance)
+
+        all_routes = set(remote_dict.keys()).union(local_dict.keys())
+
+        routes_to_add = []
+        routes_to_delete = []
+
+        for route in all_routes:
+            local_utterances = local_dict.get(route, set())
+            remote_utterances = remote_dict.get(route, set())
+
+            if self.sync == "error":
+                if local_utterances != remote_utterances:
+                    raise ValueError(f"Synchronization error: Differences found in route '{route}'")
+                utterances_to_include = set()
+            elif self.sync == "remote":
+                utterances_to_include = set()
+            elif self.sync == "local":
+                utterances_to_include = local_utterances - remote_utterances
+                routes_to_delete.extend([(route, utterance) for utterance in remote_utterances if utterance not in local_utterances])
+            elif self.sync == "merge-force-remote":
+                if route in local_dict and route not in remote_dict:
+                    utterances_to_include = local_utterances
+                else:
+                    utterances_to_include = set()
+            elif self.sync == "merge-force-local":
+                if route in local_dict:
+                    utterances_to_include = local_utterances - remote_utterances
+                    routes_to_delete.extend([(route, utterance) for utterance in remote_utterances if utterance not in local_utterances])
+                else:
+                    utterances_to_include = set()
+            elif self.sync == "merge":
+                utterances_to_include = local_utterances - remote_utterances
+            else:
+                raise ValueError("Invalid sync mode specified")
+
+            for utterance in utterances_to_include:
+                indices = [i for i, x in enumerate(local_routes['utterances']) if x == utterance and local_routes['routes'][i] == route]
+                routes_to_add.extend([(local_routes['embeddings'][idx], route, utterance) for idx in indices])
+
+        return routes_to_add, routes_to_delete
+
+
     def _batch_upsert(self, batch: List[Dict]):
         """Helper method for upserting a single batch of records."""
         if self.index is not None:
@@ -208,15 +261,33 @@ class PineconeIndex(BaseIndex):
         routes: List[str],
         utterances: List[str],
         batch_size: int = 100,
+        sync: bool = False,
     ):
         """Add vectors to Pinecone in batches."""
         if self.index is None:
             self.dimensions = self.dimensions or len(embeddings[0])
             self.index = self._init_index(force_create=True)
 
+        if sync:
+            local_routes = {"routes": routes, "utterances": utterances, "embeddings": embeddings}
+            data_to_upsert, data_to_delete = self._sync_index(local_routes=local_routes)
+
+            routes_to_delete = {}
+            for route, utterance in data_to_delete:
+                routes_to_delete.setdefault(route, []).append(utterance)
+
+            for route, utterances in routes_to_delete.items():
+                remote_routes = self._get_routes_with_ids(route_name=route)
+                ids_to_delete = [r["id"] for r in remote_routes if (r["route"], r["utterance"]) in zip([route]*len(utterances), utterances)]
+                if ids_to_delete:
+                    self.index.delete(ids=ids_to_delete)
+                
+        else:
+            data_to_upsert = zip(embeddings, routes, utterances)
+
         vectors_to_upsert = [
             PineconeRecord(values=vector, route=route, utterance=utterance).to_dict()
-            for vector, route, utterance in zip(embeddings, routes, utterances)
+            for vector, route, utterance in data_to_upsert
         ]
 
         for i in range(0, len(vectors_to_upsert), batch_size):
@@ -227,6 +298,15 @@ class PineconeIndex(BaseIndex):
         clean_route = clean_route_name(route_name)
         ids, _ = self._get_all(prefix=f"{clean_route}#")
         return ids
+    
+    def _get_routes_with_ids(self, route_name: str):
+        clean_route = clean_route_name(route_name)
+        ids, _ = self._get_all(prefix=f"{clean_route}#")
+        route_tuples = []
+        for id in ids:
+            res_meta = self.index.fetch(ids=[id], namespace=self.namespace)
+            route_tuples.extend([{"id": id, "route": x["metadata"]["sr_route"], "utterance": x["metadata"]["sr_utterance"]} for x in res_meta["vectors"].values()])
+        return route_tuples
 
     def _get_all(self, prefix: Optional[str] = None, include_metadata: bool = False):
         """

--- a/semantic_router/index/qdrant.py
+++ b/semantic_router/index/qdrant.py
@@ -169,7 +169,7 @@ class QdrantIndex(BaseIndex):
         batch_size: int = DEFAULT_UPLOAD_BATCH_SIZE,
     ):
         if sync:
-            raise NotImplementedError("Sync add is not implemented for QdrantIndex")
+            logger.warning("Sync add is not implemented for QdrantIndex")
         self.dimensions = self.dimensions or len(embeddings[0])
         self._init_collection()
 

--- a/semantic_router/index/qdrant.py
+++ b/semantic_router/index/qdrant.py
@@ -160,16 +160,24 @@ class QdrantIndex(BaseIndex):
                 **self.config,
             )
 
+    def _add_and_sync(
+        self,
+        embeddings: List[List[float]],
+        routes: List[str],
+        utterances: List[str],
+        batch_size: int = DEFAULT_UPLOAD_BATCH_SIZE,
+    ):
+        if self.sync is not None:
+            logger.warning("Sync add is not implemented for QdrantIndex")
+        self.add(embeddings, routes, utterances, batch_size)
+
     def add(
         self,
         embeddings: List[List[float]],
         routes: List[str],
         utterances: List[str],
-        sync: bool = False,
         batch_size: int = DEFAULT_UPLOAD_BATCH_SIZE,
     ):
-        if sync:
-            logger.warning("Sync add is not implemented for QdrantIndex")
         self.dimensions = self.dimensions or len(embeddings[0])
         self._init_collection()
 

--- a/semantic_router/index/qdrant.py
+++ b/semantic_router/index/qdrant.py
@@ -165,8 +165,11 @@ class QdrantIndex(BaseIndex):
         embeddings: List[List[float]],
         routes: List[str],
         utterances: List[str],
+        sync: bool = False,
         batch_size: int = DEFAULT_UPLOAD_BATCH_SIZE,
     ):
+        if sync:
+            raise NotImplementedError("Sync add is not implemented for QdrantIndex")
         self.dimensions = self.dimensions or len(embeddings[0])
         self._init_collection()
 

--- a/semantic_router/layer.py
+++ b/semantic_router/layer.py
@@ -466,11 +466,10 @@ class RouteLayer:
         # create route array
         route_names = [route.name for route in routes for _ in route.utterances]
         # add everything to the index
-        self.index.add(
+        self.index._add_and_sync(
             embeddings=embedded_utterances,
             routes=route_names,
             utterances=all_utterances,
-            sync=True,
         )
 
     def _encode(self, text: str) -> Any:

--- a/semantic_router/layer.py
+++ b/semantic_router/layer.py
@@ -470,6 +470,7 @@ class RouteLayer:
             embeddings=embedded_utterances,
             routes=route_names,
             utterances=all_utterances,
+            sync=True,
         )
 
     def _encode(self, text: str) -> Any:


### PR DESCRIPTION
### **User description**
New implementation at startup to synchronize the local index with the remote index based on the specified mode.
Modes:
- `error`: Raise an error if local and remote are not synchronized.
- `remote`: Take remote as the source of truth and update local to align.
- `local`: Take local as the source of truth and update remote to align.
- `merge-force-remote`: Merge both local and remote taking only remote routes utterances when a route with same route name is present both locally and remotely.
- `merge-force-local`: Merge both local and remote taking only local routes utterances when a route with same route name is present both locally and remotely.
- `merge`: Merge both local and remote, merging also local and remote utterances when a route with same route name is present both locally and remotely.

Can be tested with basic code like the following:

```
from semantic_router import Route
from semantic_router.encoders import OpenAIEncoder
from semantic_router.index.pinecone import PineconeIndex
from semantic_router.layer import RouteLayer


politics = Route(
    name="politics",
    utterances=[
        "isn't politics the best thing ever",
        "why don't you tell me about your political opinions",
        "don't you just love the president",
    ],
)

chitchat = Route(
    name="chitchat",
    utterances=[
        "how's the weather today?",
        "how are things going?",
    ],
)

routes = [politics, chitchat]

encoder = OpenAIEncoder(openai_api_key=openai_api_key)

pc_index = PineconeIndex(
    api_key=pinecone_api_key,
    region="us-east-1",
    index_name="alai-clearwater-routes-input-intent",
    sync="local",
)

rl = RouteLayer(encoder=encoder, routes=routes, index=pc_index)
```


___

### **PR Type**
Enhancement


___

### **Description**
- Added `sync` parameter to `BaseIndex`, `LocalIndex`, and `PineconeIndex` classes.
- Introduced `_sync_index` method with various synchronization modes in `BaseIndex` and implemented it in `PineconeIndex`.
- Modified `add` method in `PineconeIndex` to handle synchronization.
- Added `_get_routes_with_ids` method in `PineconeIndex`.
- Enabled synchronization in `RouteLayer`'s `_add_routes` method.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.py</strong><dd><code>Add sync parameter and synchronization logic to BaseIndex</code></dd></summary>
<hr>

semantic_router/index/base.py

<li>Added <code>sync</code> parameter to <code>BaseIndex</code> class.<br> <li> Introduced <code>_sync_index</code> method with various synchronization modes.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/344/files#diff-df154312e842c3302d871397cc51942d0a6e3be19183c0b362499fb8e2fcd127">+21/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>local.py</strong><dd><code>Add sync parameter to LocalIndex add method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/index/local.py

- Added `sync` parameter to `add` method.



</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/344/files#diff-3f7c4d16e4e8638997135efd56b4c4423ca8bd5f111901351d37177ca40dfe98">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pinecone.py</strong><dd><code>Add sync parameter and synchronization logic to PineconeIndex</code></dd></summary>
<hr>

semantic_router/index/pinecone.py

<li>Added <code>sync</code> parameter to <code>PineconeIndex</code> class.<br> <li> Implemented <code>_sync_index</code> method for PineconeIndex.<br> <li> Modified <code>add</code> method to handle synchronization.<br> <li> Added <code>_get_routes_with_ids</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/344/files#diff-c57f54339773ad317ee6eafd071395202933f9eeaf59a10c28fc22d06bf564a2">+125/-1</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>layer.py</strong><dd><code>Enable synchronization in RouteLayer's _add_routes method</code></dd></summary>
<hr>

semantic_router/layer.py

- Updated `_add_routes` method to enable synchronization.



</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/344/files#diff-e495ddf91e18dd7477eb129fd2c0ab7dfbaf2440534c28b6156a76acdaf51433">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

