### PR TITLE
feat: add sparse vector for PineconeIndex

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "semantic-router"
-version = "0.0.52"
+version = "0.0.53"
 description = "Super fast semantic router for AI decision making"
 authors = [
     "James Briggs <james@aurelio.ai>",

--- a/semantic_router/__init__.py
+++ b/semantic_router/__init__.py
@@ -4,4 +4,4 @@ from semantic_router.route import Route
 
 __all__ = ["RouteLayer", "HybridRouteLayer", "Route", "LayerConfig"]
 
-__version__ = "0.0.50"
+__version__ = "0.0.53"

--- a/semantic_router/index/local.py
+++ b/semantic_router/index/local.py
@@ -98,7 +98,7 @@ class LocalIndex(BaseIndex):
             scores, idx = top_scores(sim, top_k)
             route_names = [self.routes[i] for i in idx]
         return scores, route_names
-    
+
     async def aquery(
         self,
         vector: np.ndarray,

--- a/semantic_router/index/local.py
+++ b/semantic_router/index/local.py
@@ -98,6 +98,35 @@ class LocalIndex(BaseIndex):
             scores, idx = top_scores(sim, top_k)
             route_names = [self.routes[i] for i in idx]
         return scores, route_names
+    
+    async def aquery(
+        self,
+        vector: np.ndarray,
+        top_k: int = 5,
+        route_filter: Optional[List[str]] = None,
+    ) -> Tuple[np.ndarray, List[str]]:
+        """
+        Search the index for the query and return top_k results.
+        """
+        if self.index is None or self.routes is None:
+            raise ValueError("Index or routes are not populated.")
+        if route_filter is not None:
+            filtered_index = []
+            filtered_routes = []
+            for route, vec in zip(self.routes, self.index):
+                if route in route_filter:
+                    filtered_index.append(vec)
+                    filtered_routes.append(route)
+            if not filtered_routes:
+                raise ValueError("No routes found matching the filter criteria.")
+            sim = similarity_matrix(vector, np.array(filtered_index))
+            scores, idx = top_scores(sim, top_k)
+            route_names = [filtered_routes[i] for i in idx]
+        else:
+            sim = similarity_matrix(vector, self.index)
+            scores, idx = top_scores(sim, top_k)
+            route_names = [self.routes[i] for i in idx]
+        return scores, route_names
 
     def delete(self, route_name: str):
         """

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -462,6 +462,7 @@ class PineconeIndex(BaseIndex):
     def query(
         self,
         vector: np.ndarray,
+        sparse_vector: Optional[dict] = None,
         top_k: int = 5,
         route_filter: Optional[List[str]] = None,
     ) -> Tuple[np.ndarray, List[str]]:
@@ -474,6 +475,7 @@ class PineconeIndex(BaseIndex):
             filter_query = None
         results = self.index.query(
             vector=[query_vector_list],
+            sparse_vector=sparse_vector,
             top_k=top_k,
             filter=filter_query,
             include_metadata=True,
@@ -486,6 +488,7 @@ class PineconeIndex(BaseIndex):
     async def aquery(
         self,
         vector: np.ndarray,
+        sparse_vector: Optional[dict] = None,
         top_k: int = 5,
         route_filter: Optional[List[str]] = None,
     ) -> Tuple[np.ndarray, List[str]]:
@@ -498,6 +501,7 @@ class PineconeIndex(BaseIndex):
             filter_query = None
         results = await self._async_query(
             vector=query_vector_list,
+            sparse_vector=sparse_vector,
             namespace=self.namespace or "",
             filter=filter_query,
             top_k=top_k,
@@ -514,6 +518,7 @@ class PineconeIndex(BaseIndex):
     async def _async_query(
         self,
         vector: list[float],
+        sparse_vector: Optional[dict] = None,
         namespace: str = "",
         filter: Optional[dict] = None,
         top_k: int = 5,
@@ -521,6 +526,7 @@ class PineconeIndex(BaseIndex):
     ):
         params = {
             "vector": vector,
+            "sparse_vector": sparse_vector,
             "namespace": namespace,
             "filter": filter,
             "top_k": top_k,

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -475,7 +475,7 @@ class PineconeIndex(BaseIndex):
             filter_query = None
         results = self.index.query(
             vector=[query_vector_list],
-            sparse_vector=kwargs.get('sparse_vector', None),
+            sparse_vector=kwargs.get("sparse_vector", None),
             top_k=top_k,
             filter=filter_query,
             include_metadata=True,
@@ -501,7 +501,7 @@ class PineconeIndex(BaseIndex):
             filter_query = None
         results = await self._async_query(
             vector=query_vector_list,
-            sparse_vector=kwargs.get('sparse_vector', None),
+            sparse_vector=kwargs.get("sparse_vector", None),
             namespace=self.namespace or "",
             filter=filter_query,
             top_k=top_k,

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -466,6 +466,23 @@ class PineconeIndex(BaseIndex):
         route_filter: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> Tuple[np.ndarray, List[str]]:
+        """
+        Search the index for the query vector and return the top_k results.
+
+        :param vector: The query vector to search for.
+        :type vector: np.ndarray
+        :param top_k: The number of top results to return, defaults to 5.
+        :type top_k: int, optional
+        :param route_filter: A list of route names to filter the search results, defaults to None.
+        :type route_filter: Optional[List[str]], optional
+        :param kwargs: Additional keyword arguments for the query, including sparse_vector.
+        :type kwargs: Any
+        :keyword sparse_vector: An optional sparse vector to include in the query.
+        :type sparse_vector: Optional[dict]
+        :return: A tuple containing an array of scores and a list of route names.
+        :rtype: Tuple[np.ndarray, List[str]]
+        :raises ValueError: If the index is not populated.
+        """
         if self.index is None:
             raise ValueError("Index is not populated.")
         query_vector_list = vector.tolist()
@@ -492,6 +509,23 @@ class PineconeIndex(BaseIndex):
         route_filter: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> Tuple[np.ndarray, List[str]]:
+        """
+        Asynchronously search the index for the query vector and return the top_k results.
+
+        :param vector: The query vector to search for.
+        :type vector: np.ndarray
+        :param top_k: The number of top results to return, defaults to 5.
+        :type top_k: int, optional
+        :param route_filter: A list of route names to filter the search results, defaults to None.
+        :type route_filter: Optional[List[str]], optional
+        :param kwargs: Additional keyword arguments for the query, including sparse_vector.
+        :type kwargs: Any
+        :keyword sparse_vector: An optional sparse vector to include in the query.
+        :type sparse_vector: Optional[dict]
+        :return: A tuple containing an array of scores and a list of route names.
+        :rtype: Tuple[np.ndarray, List[str]]
+        :raises ValueError: If the index is not populated.
+        """
         if self.async_client is None or self.host is None:
             raise ValueError("Async client or host are not initialized.")
         query_vector_list = vector.tolist()

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -462,9 +462,9 @@ class PineconeIndex(BaseIndex):
     def query(
         self,
         vector: np.ndarray,
-        sparse_vector: Optional[dict] = None,
         top_k: int = 5,
         route_filter: Optional[List[str]] = None,
+        **kwargs: Any,
     ) -> Tuple[np.ndarray, List[str]]:
         if self.index is None:
             raise ValueError("Index is not populated.")
@@ -475,7 +475,7 @@ class PineconeIndex(BaseIndex):
             filter_query = None
         results = self.index.query(
             vector=[query_vector_list],
-            sparse_vector=sparse_vector,
+            sparse_vector=kwargs.get('sparse_vector', None),
             top_k=top_k,
             filter=filter_query,
             include_metadata=True,
@@ -488,9 +488,9 @@ class PineconeIndex(BaseIndex):
     async def aquery(
         self,
         vector: np.ndarray,
-        sparse_vector: Optional[dict] = None,
         top_k: int = 5,
         route_filter: Optional[List[str]] = None,
+        **kwargs: Any,
     ) -> Tuple[np.ndarray, List[str]]:
         if self.async_client is None or self.host is None:
             raise ValueError("Async client or host are not initialized.")
@@ -501,7 +501,7 @@ class PineconeIndex(BaseIndex):
             filter_query = None
         results = await self._async_query(
             vector=query_vector_list,
-            sparse_vector=sparse_vector,
+            sparse_vector=kwargs.get('sparse_vector', None),
             namespace=self.namespace or "",
             filter=filter_query,
             top_k=top_k,


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added `aquery` method to `local.py` for asynchronous querying with route filtering and error handling.
- Enhanced `query` and `aquery` methods in `pinecone.py` to support `sparse_vector` parameter.
- Updated `_async_query` method in `pinecone.py` to handle `sparse_vector`.
- Included `kwargs` in `pinecone.py` methods to pass additional parameters.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>local.py</strong><dd><code>Add asynchronous query method with route filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/index/local.py

<li>Added <code>aquery</code> method for asynchronous querying.<br> <li> Implemented route filtering within <code>aquery</code>.<br> <li> Added error handling for empty index or routes.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/355/files#diff-3f7c4d16e4e8638997135efd56b4c4423ca8bd5f111901351d37177ca40dfe98">+29/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pinecone.py</strong><dd><code>Support sparse vectors in Pinecone query methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/index/pinecone.py

<li>Added <code>sparse_vector</code> parameter to <code>query</code> and <code>aquery</code> methods.<br> <li> Updated <code>_async_query</code> method to handle <code>sparse_vector</code>.<br> <li> Included <code>kwargs</code> to pass additional parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/355/files#diff-c57f54339773ad317ee6eafd071395202933f9eeaf59a10c28fc22d06bf564a2">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

