### PR TITLE
feat: add ollama signature builder

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.abspath("../.."))  # Source code dir relative to this
 project = "Semantic Router"
 copyright = "2024, Aurelio AI"
 author = "Aurelio AI"
-release = "0.0.58"
+release = "0.0.59"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "semantic-router"
-version = "0.0.58"
+version = "0.0.59"
 description = "Super fast semantic router for AI decision making"
 authors = [
     "James Briggs <james@aurelio.ai>",

--- a/semantic_router/__init__.py
+++ b/semantic_router/__init__.py
@@ -4,4 +4,4 @@ from semantic_router.route import Route
 
 __all__ = ["RouteLayer", "HybridRouteLayer", "Route", "LayerConfig"]
 
-__version__ = "0.0.58"
+__version__ = "0.0.59"

--- a/semantic_router/utils/function_call.py
+++ b/semantic_router/utils/function_call.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from pydantic.v1 import BaseModel
 
@@ -14,7 +14,7 @@ class Parameter(BaseModel):
         arbitrary_types_allowed = True
 
     name: str = Field(description="The name of the parameter")
-    description: str | None = Field(
+    description: Optional[str] = Field(
         default=None, description="The description of the parameter"
     )
     type: str = Field(description="The type of the parameter")
@@ -41,7 +41,7 @@ class FunctionSchema:
     output: str = Field(description="The output of the function")
     parameters: List[Parameter] = Field(description="The parameters of the function")
 
-    def __init__(self, function: Callable | BaseModel):
+    def __init__(self, function: Union[Callable, BaseModel]):
         self.function = function
         if callable(function):
             self._process_function(function)

--- a/semantic_router/utils/function_call.py
+++ b/semantic_router/utils/function_call.py
@@ -6,6 +6,101 @@ from pydantic.v1 import BaseModel
 from semantic_router.llms import BaseLLM
 from semantic_router.schema import Message, RouteChoice
 from semantic_router.utils.logger import logger
+from pydantic import Field
+
+
+class Parameter(BaseModel):
+    class Config:
+        arbitrary_types_allowed = True
+
+    name: str = Field(description="The name of the parameter")
+    description: str | None = Field(
+        default=None, description="The description of the parameter"
+    )
+    type: str = Field(description="The type of the parameter")
+    default: Any = Field(description="The default value of the parameter")
+    required: bool = Field(description="Whether the parameter is required")
+
+    def to_ollama(self):
+        return {
+            self.name: {
+                "description": self.description,
+                "type": self.type,
+            }
+        }
+
+
+class FunctionSchema:
+    """Class that consumes a function and can return a schema required by
+    different LLMs for function calling.
+    """
+
+    name: str = Field(description="The name of the function")
+    description: str = Field(description="The description of the function")
+    signature: str = Field(description="The signature of the function")
+    output: str = Field(description="The output of the function")
+    parameters: List[Parameter] = Field(description="The parameters of the function")
+
+    def __init__(self, function: Callable | BaseModel):
+        self.function = function
+        if callable(function):
+            self._process_function(function)
+        elif isinstance(function, BaseModel):
+            raise NotImplementedError("Pydantic BaseModel not implemented yet.")
+        else:
+            raise TypeError("Function must be a Callable or BaseModel")
+
+    def _process_function(self, function: Callable):
+        self.name = function.__name__
+        self.description = str(inspect.getdoc(function))
+        self.signature = str(inspect.signature(function))
+        self.output = str(inspect.signature(function).return_annotation)
+        parameters = []
+        for param in inspect.signature(function).parameters.values():
+            parameters.append(
+                Parameter(
+                    name=param.name,
+                    type=param.annotation.__name__,
+                    default=param.default,
+                    required=False if param.default is param.empty else True,
+                )
+            )
+        self.parameters = parameters
+
+    def to_ollama(self):
+        schema_dict = {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        param.name: {
+                            "description": param.description,
+                            "type": self._ollama_type_mapping(param.type),
+                        }
+                        for param in self.parameters
+                    },
+                    "required": [
+                        param.name for param in self.parameters if param.required
+                    ],
+                },
+            },
+        }
+        return schema_dict
+
+    def _ollama_type_mapping(self, param_type: str) -> str:
+        if param_type == "int":
+            return "number"
+        elif param_type == "float":
+            return "number"
+        elif param_type == "str":
+            return "string"
+        elif param_type == "bool":
+            return "boolean"
+        else:
+            return "object"
 
 
 def get_schema_list(items: List[Union[BaseModel, Callable]]) -> List[Dict[str, Any]]:

--- a/tests/unit/test_function_schema.py
+++ b/tests/unit/test_function_schema.py
@@ -1,0 +1,44 @@
+import inspect
+from semantic_router.utils.function_call import FunctionSchema
+
+
+def scrape_webpage(url: str, name: str = "test") -> str:
+    """Provides access to web scraping. You can use this tool to scrape a webpage.
+    Many webpages may return no information due to JS or adblock issues, if this
+    happens, you must use a different URL.
+    """
+    return "hello there"
+
+
+def test_function_schema():
+    schema = FunctionSchema(scrape_webpage)
+    assert schema.name == scrape_webpage.__name__
+    assert schema.description == str(inspect.getdoc(scrape_webpage))
+    assert schema.signature == str(inspect.signature(scrape_webpage))
+    assert schema.output == str(inspect.signature(scrape_webpage).return_annotation)
+    assert len(schema.parameters) == 2
+
+
+def test_ollama_function_schema():
+    schema = FunctionSchema(scrape_webpage)
+    ollama_schema = schema.to_ollama()
+    assert ollama_schema["type"] == "function"
+    assert ollama_schema["function"]["name"] == schema.name
+    assert ollama_schema["function"]["description"] == schema.description
+    assert ollama_schema["function"]["parameters"]["type"] == "object"
+    assert (
+        ollama_schema["function"]["parameters"]["properties"]["url"]["type"] == "string"
+    )
+    assert (
+        ollama_schema["function"]["parameters"]["properties"]["name"]["type"]
+        == "string"
+    )
+    assert (
+        ollama_schema["function"]["parameters"]["properties"]["url"]["description"]
+        is None
+    )
+    assert (
+        ollama_schema["function"]["parameters"]["properties"]["name"]["description"]
+        is None
+    )
+    assert ollama_schema["function"]["parameters"]["required"] == ["name"]


### PR DESCRIPTION
Addresses #383 

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced `Parameter` class to represent function parameters with attributes like name, description, type, default value, and required status.
- Added `FunctionSchema` class to generate schemas for functions, including methods to convert these schemas to Ollama format.
- Implemented `_ollama_type_mapping` method to map Python types to Ollama types.
- Added unit tests to validate the functionality of `FunctionSchema` and its Ollama conversion.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>function_call.py</strong><dd><code>Add `Parameter` and `FunctionSchema` classes with Ollama conversion</code></dd></summary>
<hr>

semantic_router/utils/function_call.py

<li>Added <code>Parameter</code> class for function parameter representation.<br> <li> Added <code>FunctionSchema</code> class to generate function schemas for LLMs.<br> <li> Implemented methods to convert function schema to Ollama format.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/381/files#diff-d875fd1c47505b2ab8334c40a0e9aa94a6b4c72608c643f62134096db7274dbd">+95/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_function_schema.py</strong><dd><code>Add unit tests for `FunctionSchema` and Ollama conversion</code></dd></summary>
<hr>

tests/unit/test_function_schema.py

<li>Added unit tests for <code>FunctionSchema</code> class.<br> <li> Tested schema generation and Ollama conversion.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/381/files#diff-067b0640bcd84e0a2703598dd219afccf1a219a5117c68b2cf7ebf2d7db621c2">+44/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

