### PR TITLE
feat: add max_retries to OpenAI and Azure encoders

### DIFF
--- a/semantic_router/encoders/openai.py
+++ b/semantic_router/encoders/openai.py
@@ -123,11 +123,13 @@ class OpenAIEncoder(BaseEncoder):
                     break
             except OpenAIError as e:
                 logger.error("Exception occurred", exc_info=True)
-                if self.max_retries != 0:
+                if self.max_retries != 0 and j < self.max_retries:
                     sleep(2**j)
                     logger.warning(
                         f"Retrying in {2**j} seconds due to OpenAIError: {e}"
                     )
+                else:
+                    raise
 
             except Exception as e:
                 logger.error(f"OpenAI API call failed. Error: {e}")
@@ -178,11 +180,14 @@ class OpenAIEncoder(BaseEncoder):
                     break
             except OpenAIError as e:
                 logger.error("Exception occurred", exc_info=True)
-                if self.max_retries != 0:
+                if self.max_retries != 0 and j < self.max_retries:
                     await asleep(2**j)
                     logger.warning(
                         f"Retrying in {2**j} seconds due to OpenAIError: {e}"
                     )
+                else:
+                    raise
+                    
             except Exception as e:
                 logger.error(f"OpenAI API call failed. Error: {e}")
                 raise ValueError(f"OpenAI API call failed. Error: {e}") from e

--- a/semantic_router/encoders/openai.py
+++ b/semantic_router/encoders/openai.py
@@ -52,7 +52,7 @@ class OpenAIEncoder(BaseEncoder):
         openai_org_id: Optional[str] = None,
         score_threshold: Optional[float] = None,
         dimensions: Union[int, NotGiven] = NotGiven(),
-        max_retries: int | None = None,
+        max_retries: int = 3,
     ):
         if name is None:
             name = EncoderDefault.OPENAI.value["embedding_model"]

--- a/semantic_router/encoders/openai.py
+++ b/semantic_router/encoders/openai.py
@@ -114,7 +114,6 @@ class OpenAIEncoder(BaseEncoder):
         # Exponential backoff
         for j in range(self.max_retries + 1):
             try:
-                raise OpenAIError("Test")
                 embeds = self.client.embeddings.create(
                     input=docs,
                     model=self.name,
@@ -170,7 +169,6 @@ class OpenAIEncoder(BaseEncoder):
         # Exponential backoff
         for j in range(self.max_retries + 1):
             try:
-                raise OpenAIError("Test")
                 embeds = await self.async_client.embeddings.create(
                     input=docs,
                     model=self.name,

--- a/semantic_router/encoders/openai.py
+++ b/semantic_router/encoders/openai.py
@@ -187,7 +187,7 @@ class OpenAIEncoder(BaseEncoder):
                     )
                 else:
                     raise
-                    
+
             except Exception as e:
                 logger.error(f"OpenAI API call failed. Error: {e}")
                 raise ValueError(f"OpenAI API call failed. Error: {e}") from e

--- a/semantic_router/encoders/zure.py
+++ b/semantic_router/encoders/zure.py
@@ -105,7 +105,6 @@ class AzureOpenAIEncoder(BaseEncoder):
         # Exponential backoff
         for j in range(self.max_retries + 1):
             try:
-                raise OpenAIError("Test")
                 embeds = self.client.embeddings.create(
                     input=docs,
                     model=str(self.model),
@@ -142,7 +141,6 @@ class AzureOpenAIEncoder(BaseEncoder):
         # Exponential backoff
         for j in range(self.max_retries + 1):
             try:
-                raise OpenAIError("Test")
                 embeds = await self.async_client.embeddings.create(
                     input=docs,
                     model=str(self.model),

--- a/semantic_router/encoders/zure.py
+++ b/semantic_router/encoders/zure.py
@@ -34,7 +34,7 @@ class AzureOpenAIEncoder(BaseEncoder):
         model: Optional[str] = None,  # TODO we should change to `name` JB
         score_threshold: float = 0.82,
         dimensions: Union[int, NotGiven] = NotGiven(),
-        max_retries: int | None = None,
+        max_retries: int = 3,
     ):
         name = deployment_name
         if name is None:

--- a/semantic_router/encoders/zure.py
+++ b/semantic_router/encoders/zure.py
@@ -114,11 +114,13 @@ class AzureOpenAIEncoder(BaseEncoder):
                     break
             except OpenAIError as e:
                 logger.error("Exception occurred", exc_info=True)
-                if self.max_retries != 0:
+                if self.max_retries != 0 and j < self.max_retries:
                     sleep(2**j)
                     logger.warning(
                         f"Retrying in {2**j} seconds due to OpenAIError: {e}"
                     )
+                else:
+                    raise
             except Exception as e:
                 logger.error(f"Azure OpenAI API call failed. Error: {e}")
                 raise ValueError(f"Azure OpenAI API call failed. Error: {e}") from e
@@ -151,11 +153,13 @@ class AzureOpenAIEncoder(BaseEncoder):
 
             except OpenAIError as e:
                 logger.error("Exception occurred", exc_info=True)
-                if self.max_retries != 0:
+                if self.max_retries != 0 and j < self.max_retries:
                     await asleep(2**j)
                     logger.warning(
                         f"Retrying in {2**j} seconds due to OpenAIError: {e}"
                     )
+                else:
+                    raise
             except Exception as e:
                 logger.error(f"Azure OpenAI API call failed. Error: {e}")
                 raise ValueError(f"Azure OpenAI API call failed. Error: {e}") from e

--- a/semantic_router/utils/function_call.py
+++ b/semantic_router/utils/function_call.py
@@ -77,7 +77,11 @@ class FunctionSchema:
                     "type": "object",
                     "properties": {
                         param.name: {
-                            "description": param.description,
+                            "description": (
+                                param.description
+                                if isinstance(param.description, str)
+                                else None
+                            ),
                             "type": self._ollama_type_mapping(param.type),
                         }
                         for param in self.parameters

--- a/tests/integration/encoders/test_openai_integration.py
+++ b/tests/integration/encoders/test_openai_integration.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from openai import OpenAIError
 from semantic_router.encoders.base import BaseEncoder
 from semantic_router.encoders.openai import OpenAIEncoder
 
@@ -40,7 +41,7 @@ class TestOpenAIEncoder:
         os.environ.get("OPENAI_API_KEY") is None, reason="OpenAI API key required"
     )
     def test_openai_encoder_call_no_truncation(self, openai_encoder):
-        with pytest.raises(ValueError) as _:
+        with pytest.raises(OpenAIError) as _:
             # default truncation is True
             openai_encoder([long_doc], truncate=False)
 

--- a/tests/unit/encoders/test_azure.py
+++ b/tests/unit/encoders/test_azure.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import AsyncMock, Mock, patch
 from openai import OpenAIError
 from openai.types import CreateEmbeddingResponse, Embedding
 from openai.types.create_embedding_response import Usage
@@ -7,14 +8,26 @@ from semantic_router.encoders import AzureOpenAIEncoder
 
 
 @pytest.fixture
-def openai_encoder(mocker):
-    mocker.patch("openai.Client")
+def mock_openai_client():
+    with patch("openai.AzureOpenAI") as mock_client:
+        yield mock_client
+
+
+@pytest.fixture
+def mock_openai_async_client():
+    with patch("openai.AsyncAzureOpenAI") as mock_async_client:
+        yield mock_async_client
+
+
+@pytest.fixture
+def openai_encoder(mock_openai_client, mock_openai_async_client):
     return AzureOpenAIEncoder(
         api_key="test_api_key",
         deployment_name="test-deployment",
         azure_endpoint="test_endpoint",
         api_version="test_version",
         model="test_model",
+        max_retries=2,
     )
 
 
@@ -70,20 +83,9 @@ class TestAzureOpenAIEncoder:
         mocker.patch.object(
             openai_encoder.client.embeddings, "create", side_effect=responses
         )
-        embeddings = openai_encoder(["test document"])
+        with patch("semantic_router.encoders.zure.sleep", return_value=None):
+            embeddings = openai_encoder(["test document"])
         assert embeddings == [[0.1, 0.2]]
-
-    def test_openai_encoder_call_with_retries(self, openai_encoder, mocker):
-        mocker.patch("os.getenv", return_value="fake-api-key")
-        mocker.patch("time.sleep", return_value=None)  # To speed up the test
-        mocker.patch.object(
-            openai_encoder.client.embeddings,
-            "create",
-            side_effect=OpenAIError("Test error"),
-        )
-        with pytest.raises(ValueError) as e:
-            openai_encoder(["test document"])
-        assert "No embeddings returned." in str(e.value)
 
     def test_openai_encoder_call_failure_non_openai_error(self, openai_encoder, mocker):
         mocker.patch("os.getenv", return_value="fake-api-key")
@@ -93,8 +95,9 @@ class TestAzureOpenAIEncoder:
             "create",
             side_effect=Exception("Non-OpenAIError"),
         )
-        with pytest.raises(ValueError) as e:
-            openai_encoder(["test document"])
+        with patch("semantic_router.encoders.zure.sleep", return_value=None):
+            with pytest.raises(ValueError) as e:
+                openai_encoder(["test document"])
 
         assert "OpenAI API call failed. Error: Non-OpenAIError" in str(e.value)
 
@@ -120,5 +123,128 @@ class TestAzureOpenAIEncoder:
         mocker.patch.object(
             openai_encoder.client.embeddings, "create", side_effect=responses
         )
-        embeddings = openai_encoder(["test document"])
+        with patch("semantic_router.encoders.zure.sleep", return_value=None):
+            embeddings = openai_encoder(["test document"])
         assert embeddings == [[0.1, 0.2]]
+
+    def test_retry_logic_sync(self, openai_encoder, mock_openai_client, mocker):
+        # Mock the embeddings.create method to raise an error twice, then succeed
+        mock_create = Mock(
+            side_effect=[
+                OpenAIError("API error"),
+                OpenAIError("API error"),
+                CreateEmbeddingResponse(
+                    data=[
+                        Embedding(
+                            embedding=[0.1, 0.2, 0.3], index=0, object="embedding"
+                        )
+                    ],
+                    model="text-embedding-3-small",
+                    object="list",
+                    usage={"prompt_tokens": 5, "total_tokens": 5},
+                ),
+            ]
+        )
+        mock_openai_client.return_value.embeddings.create = mock_create
+        mocker.patch("time.sleep", return_value=None)  # To speed up the test
+
+        # Patch the sleep function in the encoder module to avoid actual sleep
+        with patch("semantic_router.encoders.zure.sleep", return_value=None):
+            result = openai_encoder(["test document"])
+
+        assert result == [[0.1, 0.2, 0.3]]
+        assert mock_create.call_count == 3
+
+    def test_no_retry_on_max_retries_zero(self, openai_encoder, mock_openai_client):
+        openai_encoder.max_retries = 0
+        # Mock the embeddings.create method to always raise an error
+        mock_create = Mock(side_effect=OpenAIError("API error"))
+        mock_openai_client.return_value.embeddings.create = mock_create
+
+        with pytest.raises(OpenAIError):
+            openai_encoder(["test document"])
+
+        assert mock_create.call_count == 1  # Only the initial attempt, no retries
+
+    def test_retry_logic_sync_max_retries_exceeded(
+        self, openai_encoder, mock_openai_client, mocker
+    ):
+        # Mock the embeddings.create method to always raise an error
+        mock_create = Mock(side_effect=OpenAIError("API error"))
+        mock_openai_client.return_value.embeddings.create = mock_create
+        mocker.patch("time.sleep", return_value=None)  # To speed up the test
+
+        # Patch the sleep function in the encoder module to avoid actual sleep
+        with patch("semantic_router.encoders.zure.sleep", return_value=None):
+            with pytest.raises(OpenAIError):
+                openai_encoder(["test document"])
+
+        assert mock_create.call_count == 3  # Initial attempt + 2 retries
+
+    @pytest.mark.asyncio
+    async def test_retry_logic_async(
+        self, openai_encoder, mock_openai_async_client, mocker
+    ):
+        # Set up the mock to fail twice, then succeed
+        mock_create = AsyncMock(
+            side_effect=[
+                OpenAIError("API error"),
+                OpenAIError("API error"),
+                CreateEmbeddingResponse(
+                    data=[
+                        Embedding(
+                            embedding=[0.1, 0.2, 0.3], index=0, object="embedding"
+                        )
+                    ],
+                    model="text-embedding-3-small",
+                    object="list",
+                    usage={"prompt_tokens": 5, "total_tokens": 5},
+                ),
+            ]
+        )
+        mock_openai_async_client.return_value.embeddings.create = mock_create
+        mocker.patch("asyncio.sleep", return_value=None)  # To speed up the test
+
+        # Patch the asleep function in the encoder module to avoid actual sleep
+        with patch("semantic_router.encoders.zure.asleep", return_value=None):
+            result = await openai_encoder.acall(["test document"])
+
+        assert result == [[0.1, 0.2, 0.3]]
+        assert mock_create.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_retry_logic_async_max_retries_exceeded(
+        self, openai_encoder, mock_openai_async_client, mocker
+    ):
+        # Mock the embeddings.create method to always raise an error
+        async def raise_error(*args, **kwargs):
+            raise OpenAIError("API error")
+
+        mock_create = Mock(side_effect=raise_error)
+        mock_openai_async_client.return_value.embeddings.create = mock_create
+        mocker.patch("asyncio.sleep", return_value=None)  # To speed up the test
+
+        # Patch the asleep function in the encoder module to avoid actual sleep
+        with patch("semantic_router.encoders.zure.asleep", return_value=None):
+            with pytest.raises(OpenAIError):
+                await openai_encoder.acall(["test document"])
+
+        assert mock_create.call_count == 3  # Initial attempt + 2 retries
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_max_retries_zero_async(
+        self, openai_encoder, mock_openai_async_client
+    ):
+        openai_encoder.max_retries = 0
+
+        # Mock the embeddings.create method to always raise an error
+        async def raise_error(*args, **kwargs):
+            raise OpenAIError("API error")
+
+        mock_create = AsyncMock(side_effect=raise_error)
+        mock_openai_async_client.return_value.embeddings.create = mock_create
+
+        with pytest.raises(OpenAIError):
+            await openai_encoder.acall(["test document"])
+
+        assert mock_create.call_count == 1  # Only the initial attempt, no retries

--- a/tests/unit/encoders/test_azure.py
+++ b/tests/unit/encoders/test_azure.py
@@ -83,7 +83,7 @@ class TestAzureOpenAIEncoder:
         )
         with pytest.raises(ValueError) as e:
             openai_encoder(["test document"])
-        assert "No embeddings returned. Error" in str(e.value)
+        assert "No embeddings returned." in str(e.value)
 
     def test_openai_encoder_call_failure_non_openai_error(self, openai_encoder, mocker):
         mocker.patch("os.getenv", return_value="fake-api-key")

--- a/tests/unit/encoders/test_openai.py
+++ b/tests/unit/encoders/test_openai.py
@@ -77,7 +77,7 @@ class TestOpenAIEncoder:
         )
         with pytest.raises(ValueError) as e:
             openai_encoder(["test document"])
-        assert "No embeddings returned. Error" in str(e.value)
+        assert "No embeddings returned." in str(e.value)
 
     def test_openai_encoder_call_failure_non_openai_error(self, openai_encoder, mocker):
         mocker.patch("os.getenv", return_value="fake-api-key")

--- a/tests/unit/encoders/test_openai.py
+++ b/tests/unit/encoders/test_openai.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import AsyncMock, Mock, patch
 from openai import OpenAIError
 from openai.types import CreateEmbeddingResponse, Embedding
 from openai.types.create_embedding_response import Usage
@@ -7,9 +8,20 @@ from semantic_router.encoders import OpenAIEncoder
 
 
 @pytest.fixture
-def openai_encoder(mocker):
-    mocker.patch("openai.Client")
-    return OpenAIEncoder(openai_api_key="test_api_key")
+def mock_openai_client():
+    with patch("openai.Client") as mock_client:
+        yield mock_client
+
+
+@pytest.fixture
+def mock_openai_async_client():
+    with patch("openai.AsyncClient") as mock_async_client:
+        yield mock_async_client
+
+
+@pytest.fixture
+def openai_encoder(mock_openai_client, mock_openai_async_client):
+    return OpenAIEncoder(openai_api_key="fake_key", max_retries=2)
 
 
 class TestOpenAIEncoder:
@@ -64,20 +76,9 @@ class TestOpenAIEncoder:
         mocker.patch.object(
             openai_encoder.client.embeddings, "create", side_effect=responses
         )
-        embeddings = openai_encoder(["test document"])
+        with patch("semantic_router.encoders.openai.sleep", return_value=None):
+            embeddings = openai_encoder(["test document"])
         assert embeddings == [[0.1, 0.2]]
-
-    def test_openai_encoder_call_with_retries(self, openai_encoder, mocker):
-        mocker.patch("os.getenv", return_value="fake-api-key")
-        mocker.patch("time.sleep", return_value=None)  # To speed up the test
-        mocker.patch.object(
-            openai_encoder.client.embeddings,
-            "create",
-            side_effect=OpenAIError("Test error"),
-        )
-        with pytest.raises(ValueError) as e:
-            openai_encoder(["test document"])
-        assert "No embeddings returned." in str(e.value)
 
     def test_openai_encoder_call_failure_non_openai_error(self, openai_encoder, mocker):
         mocker.patch("os.getenv", return_value="fake-api-key")
@@ -87,8 +88,9 @@ class TestOpenAIEncoder:
             "create",
             side_effect=Exception("Non-OpenAIError"),
         )
-        with pytest.raises(ValueError) as e:
-            openai_encoder(["test document"])
+        with patch("semantic_router.encoders.openai.sleep", return_value=None):
+            with pytest.raises(ValueError) as e:
+                openai_encoder(["test document"])
 
         assert "OpenAI API call failed. Error: Non-OpenAIError" in str(e.value)
 
@@ -114,5 +116,128 @@ class TestOpenAIEncoder:
         mocker.patch.object(
             openai_encoder.client.embeddings, "create", side_effect=responses
         )
-        embeddings = openai_encoder(["test document"])
+        with patch("semantic_router.encoders.openai.sleep", return_value=None):
+            embeddings = openai_encoder(["test document"])
         assert embeddings == [[0.1, 0.2]]
+
+    def test_retry_logic_sync(self, openai_encoder, mock_openai_client, mocker):
+        # Mock the embeddings.create method to raise an error twice, then succeed
+        mock_create = Mock(
+            side_effect=[
+                OpenAIError("API error"),
+                OpenAIError("API error"),
+                CreateEmbeddingResponse(
+                    data=[
+                        Embedding(
+                            embedding=[0.1, 0.2, 0.3], index=0, object="embedding"
+                        )
+                    ],
+                    model="text-embedding-3-small",
+                    object="list",
+                    usage={"prompt_tokens": 5, "total_tokens": 5},
+                ),
+            ]
+        )
+        mock_openai_client.return_value.embeddings.create = mock_create
+        mocker.patch("time.sleep", return_value=None)  # To speed up the test
+
+        # Patch the sleep function in the encoder module to avoid actual sleep
+        with patch("semantic_router.encoders.openai.sleep", return_value=None):
+            result = openai_encoder(["test document"])
+
+        assert result == [[0.1, 0.2, 0.3]]
+        assert mock_create.call_count == 3
+
+    def test_no_retry_on_max_retries_zero(self, openai_encoder, mock_openai_client):
+        openai_encoder.max_retries = 0
+        # Mock the embeddings.create method to always raise an error
+        mock_create = Mock(side_effect=OpenAIError("API error"))
+        mock_openai_client.return_value.embeddings.create = mock_create
+
+        with pytest.raises(OpenAIError):
+            openai_encoder(["test document"])
+
+        assert mock_create.call_count == 1  # Only the initial attempt, no retries
+
+    def test_retry_logic_sync_max_retries_exceeded(
+        self, openai_encoder, mock_openai_client, mocker
+    ):
+        # Mock the embeddings.create method to always raise an error
+        mock_create = Mock(side_effect=OpenAIError("API error"))
+        mock_openai_client.return_value.embeddings.create = mock_create
+        mocker.patch("time.sleep", return_value=None)  # To speed up the test
+
+        # Patch the sleep function in the encoder module to avoid actual sleep
+        with patch("semantic_router.encoders.openai.sleep", return_value=None):
+            with pytest.raises(OpenAIError):
+                openai_encoder(["test document"])
+
+        assert mock_create.call_count == 3  # Initial attempt + 2 retries
+
+    @pytest.mark.asyncio
+    async def test_retry_logic_async(
+        self, openai_encoder, mock_openai_async_client, mocker
+    ):
+        # Set up the mock to fail twice, then succeed
+        mock_create = AsyncMock(
+            side_effect=[
+                OpenAIError("API error"),
+                OpenAIError("API error"),
+                CreateEmbeddingResponse(
+                    data=[
+                        Embedding(
+                            embedding=[0.1, 0.2, 0.3], index=0, object="embedding"
+                        )
+                    ],
+                    model="text-embedding-3-small",
+                    object="list",
+                    usage={"prompt_tokens": 5, "total_tokens": 5},
+                ),
+            ]
+        )
+        mock_openai_async_client.return_value.embeddings.create = mock_create
+        mocker.patch("asyncio.sleep", return_value=None)  # To speed up the test
+
+        # Patch the asleep function in the encoder module to avoid actual sleep
+        with patch("semantic_router.encoders.openai.asleep", return_value=None):
+            result = await openai_encoder.acall(["test document"])
+
+        assert result == [[0.1, 0.2, 0.3]]
+        assert mock_create.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_retry_logic_async_max_retries_exceeded(
+        self, openai_encoder, mock_openai_async_client, mocker
+    ):
+        # Mock the embeddings.create method to always raise an error
+        async def raise_error(*args, **kwargs):
+            raise OpenAIError("API error")
+
+        mock_create = Mock(side_effect=raise_error)
+        mock_openai_async_client.return_value.embeddings.create = mock_create
+        mocker.patch("asyncio.sleep", return_value=None)  # To speed up the test
+
+        # Patch the asleep function in the encoder module to avoid actual sleep
+        with patch("semantic_router.encoders.openai.asleep", return_value=None):
+            with pytest.raises(OpenAIError):
+                await openai_encoder.acall(["test document"])
+
+        assert mock_create.call_count == 3  # Initial attempt + 2 retries
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_max_retries_zero_async(
+        self, openai_encoder, mock_openai_async_client
+    ):
+        openai_encoder.max_retries = 0
+
+        # Mock the embeddings.create method to always raise an error
+        async def raise_error(*args, **kwargs):
+            raise OpenAIError("API error")
+
+        mock_create = AsyncMock(side_effect=raise_error)
+        mock_openai_async_client.return_value.embeddings.create = mock_create
+
+        with pytest.raises(OpenAIError):
+            await openai_encoder.acall(["test document"])
+
+        assert mock_create.call_count == 1  # Only the initial attempt, no retries


### PR DESCRIPTION
### **User description**
This update introduces a `max_retries` option for the `OpenAIEncoder` and `AzureOpenAIEncoder` classes. This option allows users to specify the maximum number of retry attempts for API calls in case of errors. By default, it is set to 3 retries. If no retries are needed, you can set `max_retries` to 0.

#### Example:
```python
from semantic_router.encoders import OpenAIEncoder

encoder = OpenAIEncoder(name="text-embedding-3-large", max_retries=2)
```


___

### **PR Type**
enhancement


___

### **Description**
- Introduced a `max_retries` option for both `OpenAIEncoder` and `AzureOpenAIEncoder` classes, allowing users to specify the maximum number of retry attempts for API calls.
- Implemented exponential backoff retry logic for handling API call failures in both synchronous and asynchronous methods.
- Enhanced error logging to provide more detailed information on exceptions.
- Removed redundant error message handling to streamline code.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openai.py</strong><dd><code>Add retry logic and error handling to OpenAIEncoder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/encoders/openai.py

<li>Added <code>max_retries</code> attribute to <code>OpenAIEncoder</code> class with a default <br>value of 3.<br> <li> Implemented retry logic using exponential backoff for API calls.<br> <li> Improved error logging and handling for API call failures.<br> <li> Removed redundant error message variable.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/389/files#diff-957e3e71dd8cd9c500e3984ad73ff930491a9c39abed9f0ba931a1a3571fc2fc">+26/-15</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>zure.py</strong><dd><code>Add retry logic and error handling to AzureOpenAIEncoder</code>&nbsp; </dd></summary>
<hr>

semantic_router/encoders/zure.py

<li>Added <code>max_retries</code> attribute to <code>AzureOpenAIEncoder</code> class with a default <br>value of 3.<br> <li> Implemented retry logic using exponential backoff for API calls.<br> <li> Improved error logging and handling for API call failures.<br> <li> Removed redundant error message variable.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/389/files#diff-2d36bba29a7a17622ea844c40fbe1e00fb0e7e5ab20a4844800c1e0ef8f342a3">+25/-22</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

