### PR TITLE
fix: namespace in sync routes deletion

### DIFF
--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -331,7 +331,7 @@ class PineconeIndex(BaseIndex):
                 in zip([route] * len(utterances), utterances)
             ]
             if ids_to_delete and self.index:
-                self.index.delete(ids=ids_to_delete)
+                self.index.delete(ids=ids_to_delete, namespace=self.namespace)
 
     def _get_route_ids(self, route_name: str):
         clean_route = clean_route_name(route_name)


### PR DESCRIPTION
### **User description**
Related to issue #393 
Now able to delete routes at startup with sync setting enabled when using a namespace


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Added a `namespace` argument to the `delete` method in the `_remove_and_sync` function to ensure that routes are deleted with the correct namespace.
- This change addresses the issue where routes could not be deleted at startup when the sync setting was enabled and a namespace was used.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pinecone.py</strong><dd><code>Add namespace argument to route deletion in Pinecone index</code></dd></summary>
<hr>

semantic_router/index/pinecone.py

<li>Added <code>namespace</code> argument to the <code>delete</code> method call in <br><code>_remove_and_sync</code>.<br> <li> Ensures routes are deleted with the correct namespace.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/394/files#diff-c57f54339773ad317ee6eafd071395202933f9eeaf59a10c28fc22d06bf564a2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

