### PR TITLE
feat: Implemented aget_routes async method for pinecone index

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.abspath("../.."))  # Source code dir relative to this
 project = "Semantic Router"
 copyright = "2024, Aurelio AI"
 author = "Aurelio AI"
-release = "0.0.60"
+release = "0.0.61"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "semantic-router"
-version = "0.0.60"
+version = "0.0.61"
 description = "Super fast semantic router for AI decision making"
 authors = [
     "James Briggs <james@aurelio.ai>",

--- a/semantic_router/__init__.py
+++ b/semantic_router/__init__.py
@@ -4,4 +4,4 @@ from semantic_router.route import Route
 
 __all__ = ["RouteLayer", "HybridRouteLayer", "Route", "LayerConfig"]
 
-__version__ = "0.0.60"
+__version__ = "0.0.61"

--- a/semantic_router/index/base.py
+++ b/semantic_router/index/base.py
@@ -90,6 +90,17 @@ class BaseIndex(BaseModel):
         """
         raise NotImplementedError("This method should be implemented by subclasses.")
 
+    def aget_routes(self):
+        """
+        Asynchronously get a list of route and utterance objects currently stored in the index.
+        This method should be implemented by subclasses.
+
+        :returns: A list of tuples, each containing a route name and an associated utterance.
+        :rtype: list[tuple]
+        :raises NotImplementedError: If the method is not implemented by the subclass.
+        """
+        raise NotImplementedError("This method should be implemented by subclasses.")
+
     def delete_index(self):
         """
         Deletes or resets the index.

--- a/semantic_router/index/local.py
+++ b/semantic_router/index/local.py
@@ -128,6 +128,9 @@ class LocalIndex(BaseIndex):
             route_names = [self.routes[i] for i in idx]
         return scores, route_names
 
+    def aget_routes(self):
+        logger.error("Sync remove is not implemented for LocalIndex.")
+
     def delete(self, route_name: str):
         """
         Delete all records of a specific route from the index.

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -667,9 +667,6 @@ class PineconeIndex(BaseIndex):
         ) as response:
             if response.status != 200:
                 error_text = await response.text()
-                print(
-                    f"Error fetching metadata for vector {vector_id}: {response.status} - {error_text}"
-                )
                 return {}
 
             try:

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -674,9 +674,7 @@ class PineconeIndex(BaseIndex):
             try:
                 response_data = await response.json(content_type=None)
             except Exception as e:
-                logger.warning(
-                    f"No metadata found for vector {vector_id}: {e}"
-                )
+                logger.warning(f"No metadata found for vector {vector_id}: {e}")
                 return {}
 
             return (

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -674,7 +674,6 @@ class PineconeIndex(BaseIndex):
 
             try:
                 response_data = await response.json(content_type=None)
-                print(f"RESPONSE: {response_data}")
             except Exception as e:
                 return {}
 

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -628,7 +628,6 @@ class PineconeIndex(BaseIndex):
             ) as response:
                 if response.status != 200:
                     error_text = await response.text()
-                    print(f"Error listing vectors: {response.status} - {error_text}")
                     break
 
                 response_data = await response.json(content_type=None)

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -691,7 +691,6 @@ class PineconeIndex(BaseIndex):
             List[Tuple]: A list of (route_name, utterance) objects.
         """
         _, metadata = await self._async_get_all(include_metadata=True)
-        print(metadata)
         route_tuples = [(x["sr_route"], x["sr_utterance"]) for x in metadata]
         return route_tuples
 

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -628,6 +628,7 @@ class PineconeIndex(BaseIndex):
             ) as response:
                 if response.status != 200:
                     error_text = await response.text()
+                    logger.error(f"Error fetching vectors: {error_text}")
                     break
 
                 response_data = await response.json(content_type=None)
@@ -667,11 +668,15 @@ class PineconeIndex(BaseIndex):
         ) as response:
             if response.status != 200:
                 error_text = await response.text()
+                logger.error(f"Error fetching metadata: {error_text}")
                 return {}
 
             try:
                 response_data = await response.json(content_type=None)
             except Exception as e:
+                logger.warning(
+                    f"No metadata found for vector {vector_id}: {e}"
+                )
                 return {}
 
             return (

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -692,7 +692,6 @@ class PineconeIndex(BaseIndex):
             List[Tuple]: A list of (route_name, utterance) objects.
         """
         _, metadata = await self._async_get_all(include_metadata=True)
-        print("AAAAAAAAAAAAAAAAAAA")
         print(metadata)
         route_tuples = [(x["sr_route"], x["sr_utterance"]) for x in metadata]
         return route_tuples

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -597,7 +597,7 @@ class PineconeIndex(BaseIndex):
             return await response.json(content_type=None)
 
     async def _async_get_all(
-        self, prefix: str | None = None, include_metadata: bool = False
+        self, prefix: Optional[str] = None, include_metadata: bool = False
     ) -> tuple[list[str], list[dict]]:
         """
         Retrieves all vector IDs from the Pinecone index using pagination asynchronously.

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -528,6 +528,18 @@ class PineconeIndex(BaseIndex):
         route_names = [result["metadata"]["sr_route"] for result in results["matches"]]
         return np.array(scores), route_names
 
+    async def aget_routes(self) -> list[tuple]:
+        """
+        Asynchronously get a list of route and utterance objects currently stored in the index.
+
+        Returns:
+            List[Tuple]: A list of (route_name, utterance) objects.
+        """
+        if self.async_client is None or self.host is None:
+            raise ValueError("Async client or host are not initialized.")
+
+        return await self._async_get_routes()
+
     def delete_index(self):
         self.client.delete_index(self.index_name)
 
@@ -583,6 +595,107 @@ class PineconeIndex(BaseIndex):
     async def _async_describe_index(self, name: str):
         async with self.async_client.get(f"{self.base_url}/indexes/{name}") as response:
             return await response.json(content_type=None)
+
+    async def _async_get_all(
+        self, prefix: str | None = None, include_metadata: bool = False
+    ) -> tuple[list[str], list[dict]]:
+        """
+        Retrieves all vector IDs from the Pinecone index using pagination asynchronously.
+        """
+        if self.index is None:
+            raise ValueError("Index is None, could not retrieve vector IDs.")
+
+        all_vector_ids = []
+        next_page_token = None
+
+        if prefix:
+            prefix_str = f"?prefix={prefix}"
+        else:
+            prefix_str = ""
+
+        list_url = f"https://{self.host}/vectors/list{prefix_str}"
+        params: dict = {}
+        if self.namespace:
+            params["namespace"] = self.namespace
+        metadata = []
+
+        while True:
+            if next_page_token:
+                params["paginationToken"] = next_page_token
+
+            async with self.async_client.get(
+                list_url, params=params, headers={"Api-Key": self.api_key}
+            ) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    print(f"Error listing vectors: {response.status} - {error_text}")
+                    break
+
+                response_data = await response.json(content_type=None)
+
+            vector_ids = [vec["id"] for vec in response_data.get("vectors", [])]
+            if not vector_ids:
+                break
+            all_vector_ids.extend(vector_ids)
+
+            if include_metadata:
+                metadata_tasks = [self._async_fetch_metadata(id) for id in vector_ids]
+                metadata_results = await asyncio.gather(*metadata_tasks)
+                metadata.extend(metadata_results)
+
+            next_page_token = response_data.get("pagination", {}).get("next")
+            if not next_page_token:
+                break
+
+        return all_vector_ids, metadata
+
+    async def _async_fetch_metadata(self, vector_id: str) -> dict:
+        """
+        Fetch metadata for a single vector ID asynchronously using the async_client.
+        """
+        url = f"https://{self.host}/vectors/fetch"
+
+        params = {
+            "ids": [vector_id],
+        }
+
+        headers = {
+            "Api-Key": self.api_key,
+        }
+
+        async with self.async_client.get(
+            url, params=params, headers=headers
+        ) as response:
+            if response.status != 200:
+                error_text = await response.text()
+                print(
+                    f"Error fetching metadata for vector {vector_id}: {response.status} - {error_text}"
+                )
+                return {}
+
+            try:
+                response_data = await response.json(content_type=None)
+                print(f"RESPONSE: {response_data}")
+            except Exception as e:
+                print(f"Failed to decode JSON for vector {vector_id}: {e}")
+                return {}
+
+            return (
+                response_data.get("vectors", {}).get(vector_id, {}).get("metadata", {})
+            )
+
+    async def _async_get_routes(self) -> list[tuple]:
+        """
+        Gets a list of route and utterance objects currently stored in the index.
+
+        Returns:
+            List[Tuple]: A list of (route_name, utterance) objects.
+        """
+        _, metadata = await self._async_get_all(include_metadata=True)
+        print("AAAAAAAAAAAAAAAAAAA")
+        print(metadata)
+        route_tuples = [(x["sr_route"], x["sr_utterance"]) for x in metadata]
+        return route_tuples
 
     def __len__(self):
         return self.index.describe_index_stats()["total_vector_count"]

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -676,7 +676,6 @@ class PineconeIndex(BaseIndex):
                 response_data = await response.json(content_type=None)
                 print(f"RESPONSE: {response_data}")
             except Exception as e:
-                print(f"Failed to decode JSON for vector {vector_id}: {e}")
                 return {}
 
             return (

--- a/semantic_router/index/postgres.py
+++ b/semantic_router/index/postgres.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 
 from semantic_router.index.base import BaseIndex
 from semantic_router.schema import Metric
+from semantic_router.utils.logger import logger
 
 
 class MetricPgVecOperatorMap(Enum):
@@ -455,6 +456,9 @@ class PostgresIndex(BaseIndex):
         with self.conn.cursor() as cur:
             cur.execute(f"DROP TABLE IF EXISTS {table_name}")
             self.conn.commit()
+
+    def aget_routes(self):
+        logger.error("Sync remove is not implemented for PostgresIndex.")
 
     def __len__(self):
         """

--- a/semantic_router/index/qdrant.py
+++ b/semantic_router/index/qdrant.py
@@ -317,6 +317,9 @@ class QdrantIndex(BaseIndex):
         route_names = [result.payload[SR_ROUTE_PAYLOAD_KEY] for result in results]
         return np.array(scores), route_names
 
+    def aget_routes(self):
+        logger.error("Sync remove is not implemented for QdrantIndex.")
+
     def delete_index(self):
         self.client.delete_collection(self.index_name)
 

--- a/tests/unit/encoders/test_vit.py
+++ b/tests/unit/encoders/test_vit.py
@@ -7,7 +7,6 @@ from PIL import Image
 from semantic_router.encoders import VitEncoder
 
 test_model_name = "aurelio-ai/sr-test-vit"
-vit_encoder = VitEncoder(name=test_model_name)
 embed_dim = 32
 
 if torch.cuda.is_available():
@@ -53,6 +52,7 @@ class TestVitEncoder:
         os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
     )
     def test_vit_encoder_initialization(self):
+        vit_encoder = VitEncoder(name=test_model_name)
         assert vit_encoder.name == test_model_name
         assert vit_encoder.type == "huggingface"
         assert vit_encoder.score_threshold == 0.5
@@ -62,6 +62,7 @@ class TestVitEncoder:
         os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
     )
     def test_vit_encoder_call(self, dummy_pil_image):
+        vit_encoder = VitEncoder(name=test_model_name)
         encoded_images = vit_encoder([dummy_pil_image] * 3)
 
         assert len(encoded_images) == 3
@@ -71,6 +72,7 @@ class TestVitEncoder:
         os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
     )
     def test_vit_encoder_call_misshaped(self, dummy_pil_image, misshaped_pil_image):
+        vit_encoder = VitEncoder(name=test_model_name)
         encoded_images = vit_encoder([dummy_pil_image, misshaped_pil_image])
 
         assert len(encoded_images) == 2
@@ -80,6 +82,7 @@ class TestVitEncoder:
         os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
     )
     def test_vit_encoder_process_images_device(self, dummy_pil_image):
+        vit_encoder = VitEncoder(name=test_model_name)
         imgs = vit_encoder._process_images([dummy_pil_image] * 3)["pixel_values"]
 
         assert imgs.device.type == device
@@ -88,6 +91,7 @@ class TestVitEncoder:
         os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
     )
     def test_vit_encoder_ensure_rgb(self, dummy_black_and_white_img):
+        vit_encoder = VitEncoder(name=test_model_name)
         rgb_image = vit_encoder._ensure_rgb(dummy_black_and_white_img)
 
         assert rgb_image.mode == "RGB"

--- a/tests/unit/encoders/test_vit.py
+++ b/tests/unit/encoders/test_vit.py
@@ -43,11 +43,6 @@ class TestVitEncoder:
         with pytest.raises(ImportError):
             VitEncoder()
 
-    def test_vit_encoder__import_errors_torchvision(self, mocker):
-        mocker.patch.dict("sys.modules", {"torchvision": None})
-        with pytest.raises(ImportError):
-            VitEncoder()
-
     @pytest.mark.skipif(
         os.environ.get("RUN_HF_TESTS") is None, reason="Set RUN_HF_TESTS=1 to run"
     )


### PR DESCRIPTION
### **User description**
Fixes issue #396


___

### **PR Type**
enhancement


___

### **Description**
- Introduced an abstract `aget_routes` method in the base index class to be implemented by subclasses.
- Implemented the `aget_routes` method in the Pinecone index to asynchronously retrieve route and utterance objects.
- Added error logging for the `aget_routes` method in LocalIndex, PostgresIndex, and QdrantIndex to indicate it is not implemented.
- Added helper methods in PineconeIndex for asynchronous data retrieval and metadata fetching.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.py</strong><dd><code>Introduce abstract `aget_routes` method in base index class</code></dd></summary>
<hr>

semantic_router/index/base.py

<li>Added <code>aget_routes</code> method as an abstract method to be implemented by <br>subclasses.<br> <li> Described the method's purpose and expected return type.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/397/files#diff-df154312e842c3302d871397cc51942d0a6e3be19183c0b362499fb8e2fcd127">+11/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>local.py</strong><dd><code>Add `aget_routes` method with error logging in LocalIndex</code></dd></summary>
<hr>

semantic_router/index/local.py

<li>Implemented <code>aget_routes</code> method with a logger error message indicating <br>it's not implemented.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/397/files#diff-3f7c4d16e4e8638997135efd56b4c4423ca8bd5f111901351d37177ca40dfe98">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pinecone.py</strong><dd><code>Implement asynchronous `aget_routes` method in PineconeIndex</code></dd></summary>
<hr>

semantic_router/index/pinecone.py

<li>Implemented <code>aget_routes</code> method to asynchronously retrieve routes and <br>utterances.<br> <li> Added helper methods <code>_async_get_all</code> and <code>_async_fetch_metadata</code> for <br>fetching data.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/397/files#diff-c57f54339773ad317ee6eafd071395202933f9eeaf59a10c28fc22d06bf564a2">+113/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>postgres.py</strong><dd><code>Add `aget_routes` method with error logging in PostgresIndex</code></dd></summary>
<hr>

semantic_router/index/postgres.py

<li>Added <code>aget_routes</code> method with a logger error message indicating it's <br>not implemented.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/397/files#diff-01032ae019fc271b0b8f1c00c1ff48e9691b1c1c89dceeaa1334620fe5485e49">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>qdrant.py</strong><dd><code>Add `aget_routes` method with error logging in QdrantIndex</code></dd></summary>
<hr>

semantic_router/index/qdrant.py

<li>Added <code>aget_routes</code> method with a logger error message indicating it's <br>not implemented.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/397/files#diff-18adc175ce21cd450365b5e67aba1d52b08fc55e8075e09df17d68559cece844">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

