### PR TITLE
feat: Passes base_url to Pinecone client

### DIFF
--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -101,7 +101,11 @@ class PineconeIndex(BaseIndex):
                 "You can install it with: "
                 "`pip install 'semantic-router[pinecone]'`"
             )
-        pinecone_args = {"api_key": api_key, "source_tag": "semanticrouter"}
+        pinecone_args = {
+            "api_key": api_key,
+            "source_tag": "semanticrouter",
+            "host": self.base_url,
+        }
         if self.namespace:
             pinecone_args["namespace"] = self.namespace
 


### PR DESCRIPTION
Allows `PineconeIndex` to configure the Pinecone client with a different host rather than `api.pinecone.io`