### PR TITLE
feat: Batch encoding for TEI encoder

### DIFF
--- a/semantic_router/encoders/huggingface.py
+++ b/semantic_router/encoders/huggingface.py
@@ -211,18 +211,21 @@ class HFEndpointEncoder(BaseEncoder):
         Raises:
             ValueError: If no embeddings are returned for a document.
         """
-        embeddings = []
-        for d in docs:
-            try:
-                output = self.query({"inputs": d, "parameters": {}})
-                if not output or len(output) == 0:
-                    raise ValueError("No embeddings returned from the query.")
-                embeddings.append(output)
 
+        batch_size=50
+        embeddings = []
+        for i in range(0, len(docs), batch_size):
+            batch = docs[i:i + batch_size]
+            try:
+                outputs = self.query({"inputs": batch, "parameters": {}})
+                if not outputs or len(outputs) == 0:
+                    raise ValueError("No embeddings returned from the query.")
+                embeddings.extend(outputs)
             except Exception as e:
                 raise ValueError(
-                    f"No embeddings returned for document. Error: {e}"
+                    f"No embeddings returned for batch. Error: {e}"
                 ) from e
+
         return embeddings
 
     def query(self, payload, max_retries=3, retry_interval=5):

--- a/semantic_router/encoders/huggingface.py
+++ b/semantic_router/encoders/huggingface.py
@@ -212,19 +212,17 @@ class HFEndpointEncoder(BaseEncoder):
             ValueError: If no embeddings are returned for a document.
         """
 
-        batch_size=50
+        batch_size = 50
         embeddings = []
         for i in range(0, len(docs), batch_size):
-            batch = docs[i:i + batch_size]
+            batch = docs[i : i + batch_size]
             try:
                 outputs = self.query({"inputs": batch, "parameters": {}})
                 if not outputs or len(outputs) == 0:
                     raise ValueError("No embeddings returned from the query.")
-                embeddings.extend(outputs)
+                embeddings = embeddings + outputs
             except Exception as e:
-                raise ValueError(
-                    f"No embeddings returned for batch. Error: {e}"
-                ) from e
+                raise ValueError(f"No embeddings returned for batch. Error: {e}") from e
 
         return embeddings
 

--- a/semantic_router/encoders/huggingface.py
+++ b/semantic_router/encoders/huggingface.py
@@ -276,4 +276,4 @@ class HFEndpointEncoder(BaseEncoder):
                         f"Query failed with status {response.status_code}: {response.text}"
                     )
 
-        return response.json()[0]   # It returns List[List[List[float]]
+        return response.json()

--- a/semantic_router/encoders/huggingface.py
+++ b/semantic_router/encoders/huggingface.py
@@ -261,6 +261,7 @@ class HFEndpointEncoder(BaseEncoder):
                         continue
                 else:
                     response.raise_for_status()
+                    break
 
             except requests.exceptions.RequestException:
                 if attempt < max_retries - 1:
@@ -272,4 +273,4 @@ class HFEndpointEncoder(BaseEncoder):
                         f"Query failed with status {response.status_code}: {response.text}"
                     )
 
-        return response.json()
+        return response.json()[0]   # It returns List[List[List[float]]

--- a/semantic_router/encoders/huggingface.py
+++ b/semantic_router/encoders/huggingface.py
@@ -220,7 +220,10 @@ class HFEndpointEncoder(BaseEncoder):
                 outputs = self.query({"inputs": batch, "parameters": {}})
                 if not outputs or len(outputs) == 0:
                     raise ValueError("No embeddings returned from the query.")
-                embeddings = embeddings + outputs
+                if isinstance(outputs[0], list):
+                    embeddings.extend(outputs)
+                else:
+                    embeddings.append(outputs)
             except Exception as e:
                 raise ValueError(f"No embeddings returned for batch. Error: {e}") from e
 


### PR DESCRIPTION
Related to PR#414.

From user:
-----
Hi everyone.

I wanted to use the Text Embeddings Inference with the encoder but I noticed two small bugs in the code. I believe that the HFEndpointEncoder was intentionally created to be used with TEI (right?)

1.  The loop for max_retries in attempts, that is inside of the function query, has no break or any system to return the result when we have a success response. I added a break, similar to the OpenAI encoder.

2. The response from TEI is [[[array]]]. The array is inside of a list of a list. I remove one list when receiving the response. Without this it will throw a dimension error when comparing all the vectors.

These are the main bugs, but I would also take some time to purpose a future update. With TEI we can send a batch of texts

```
curl 127.0.0.1:8080/embed \
    -X POST \
    -d '{"inputs":["Today is a nice day", "I like you"]}' \
    -H 'Content-Type: application/json'
```

To save time, we could batch the different sentences to the endpoint. This would be great for longer document. If it sounds interesting I can try to help to develop it.

By the way, should I use semantic router for splitting text, or the semantic chunkers?