### PR TITLE
fix: cohere type

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -580,13 +580,13 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cohere"
-version = "5.9.0"
+version = "5.9.4"
 description = ""
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "cohere-5.9.0-py3-none-any.whl", hash = "sha256:7c70cc9e6ade3355e00aa4a77fcb5662b32261a3237e00975d92b97bb5f3c0c9"},
-    {file = "cohere-5.9.0.tar.gz", hash = "sha256:74e5b6e1fed0f617c26dfb8ef1cfccf8334321a51cc886c37374047916d71568"},
+    {file = "cohere-5.9.4-py3-none-any.whl", hash = "sha256:d1b31d8ba32e338b3aa91737aa98dc74de8778ed8e397ab799739b5f060f44e7"},
+    {file = "cohere-5.9.4.tar.gz", hash = "sha256:ed0fa256c51423175c208650dffcb534ae112dc3ab7703de352e2adaf99dd50b"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 python = ">=3.9,<3.13"
 pydantic = "^2.5.3"
 openai = ">=1.10.0,<2.0.0"
-cohere = ">=5.00,<6.00"
+cohere = ">=5.9.4,<6.00"
 mistralai= {version = ">=0.0.12,<0.1.0", optional = true}
 numpy = "^1.25.2"
 colorlog = "^6.8.0"

--- a/semantic_router/encoders/cohere.py
+++ b/semantic_router/encoders/cohere.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Optional
 
 import cohere
-from cohere.types.embed_response import EmbedResponse_EmbeddingsByType
+from cohere.types.embed_response import EmbeddingsByTypeEmbedResponse
 
 from semantic_router.encoders import BaseEncoder
 from semantic_router.utils.defaults import EncoderDefault
@@ -46,7 +46,7 @@ class CohereEncoder(BaseEncoder):
                 texts=docs, input_type=self.input_type, model=self.name
             )
             # Check for unsupported type.
-            if isinstance(embeds, EmbedResponse_EmbeddingsByType):
+            if isinstance(embeds, EmbeddingsByTypeEmbedResponse):
                 raise NotImplementedError(
                     "Handling of EmbedByTypeResponseEmbeddings is not implemented."
                 )


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the import statement for `EmbeddingsByTypeEmbedResponse` in `cohere.py`.
- Updated the type check to use the correct class `EmbeddingsByTypeEmbedResponse` instead of `EmbedResponse_EmbeddingsByType`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cohere.py</strong><dd><code>Fix import and type check for Cohere embeddings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/encoders/cohere.py

<li>Fixed import statement for <code>EmbeddingsByTypeEmbedResponse</code>.<br> <li> Updated type check from <code>EmbedResponse_EmbeddingsByType</code> to <br><code>EmbeddingsByTypeEmbedResponse</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/431/files#diff-63f98a7f33cadbad5e7fc0ad2984d0cb0f16535da13c3b99508ea6fe9e3a6ba8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information