### PR TITLE
feat: Update route thresholds manually

### DIFF
--- a/semantic_router/layer.py
+++ b/semantic_router/layer.py
@@ -177,7 +177,7 @@ class RouteLayer:
     index: BaseIndex
 
     def __init__(
-        self,
+        self
         encoder: Optional[BaseEncoder] = None,
         llm: Optional[BaseLLM] = None,
         routes: Optional[List[Route]] = None,
@@ -832,22 +832,6 @@ class RouteLayer:
 
     def _get_route_names(self) -> List[str]:
         return [route.name for route in self.routes]
-    
-    def update_route_thresholds(self, threshold_dict: Dict[str, float]):
-        """
-        Update thresholds for specified routes.
-
-        :param threshold_dict: A dictionary mapping route names to new threshold values.
-        :type threshold_dict: Dict[str, float]
-        """
-        for route_name, new_threshold in threshold_dict.items():
-            route = self.get(route_name)
-            if route:
-                old_threshold = route.score_threshold
-                route.score_threshold = new_threshold
-                logger.info(f"Updated threshold for route '{route_name}' from {old_threshold} to {new_threshold}")
-            else:
-                logger.warning(f"Route '{route_name}' not found. Skipping threshold update.")
 
 
 def threshold_random_search(

--- a/semantic_router/layer.py
+++ b/semantic_router/layer.py
@@ -832,6 +832,22 @@ class RouteLayer:
 
     def _get_route_names(self) -> List[str]:
         return [route.name for route in self.routes]
+    
+    def update_route_thresholds(self, threshold_dict: Dict[str, float]):
+        """
+        Update thresholds for specified routes.
+
+        :param threshold_dict: A dictionary mapping route names to new threshold values.
+        :type threshold_dict: Dict[str, float]
+        """
+        for route_name, new_threshold in threshold_dict.items():
+            route = self.get(route_name)
+            if route:
+                old_threshold = route.score_threshold
+                route.score_threshold = new_threshold
+                logger.info(f"Updated threshold for route '{route_name}' from {old_threshold} to {new_threshold}")
+            else:
+                logger.warning(f"Route '{route_name}' not found. Skipping threshold update.")
 
 
 def threshold_random_search(

--- a/semantic_router/layer.py
+++ b/semantic_router/layer.py
@@ -435,7 +435,12 @@ class RouteLayer:
     def list_route_names(self) -> List[str]:
         return [route.name for route in self.routes]
 
-    def update(self, name: str, threshold: Optional[float] = None, utterances: Optional[List[str]] = None):
+    def update(
+        self,
+        name: str,
+        threshold: Optional[float] = None,
+        utterances: Optional[List[str]] = None,
+    ):
         """Updates the route specified in name. Allows the update of
         threshold and/or utterances. If no values are provided via the
         threshold or utterances parameters, those fields are not updated.
@@ -446,16 +451,22 @@ class RouteLayer:
         """
 
         if threshold is None and utterances is None:
-            raise ValueError("At least one of 'threshold' or 'utterances' must be provided.")
+            raise ValueError(
+                "At least one of 'threshold' or 'utterances' must be provided."
+            )
         if utterances:
-            raise NotImplementedError("The update method cannot be used for updating utterances yet.")
-        
+            raise NotImplementedError(
+                "The update method cannot be used for updating utterances yet."
+            )
+
         route = self.get(name)
         if route:
             if threshold:
                 old_threshold = route.score_threshold
                 route.score_threshold = threshold
-                logger.info(f"Updated threshold for route '{route.name}' from {old_threshold} to {threshold}")
+                logger.info(
+                    f"Updated threshold for route '{route.name}' from {old_threshold} to {threshold}"
+                )
         else:
             raise ValueError(f"Route '{name}' not found. Nothing updated.")
 

--- a/semantic_router/layer.py
+++ b/semantic_router/layer.py
@@ -177,7 +177,7 @@ class RouteLayer:
     index: BaseIndex
 
     def __init__(
-        self
+        self,
         encoder: Optional[BaseEncoder] = None,
         llm: Optional[BaseLLM] = None,
         routes: Optional[List[Route]] = None,
@@ -435,8 +435,29 @@ class RouteLayer:
     def list_route_names(self) -> List[str]:
         return [route.name for route in self.routes]
 
-    def update(self, route_name: str, utterances: List[str]):
-        raise NotImplementedError("This method has not yet been implemented.")
+    def update(self, name: str, threshold: Optional[float] = None, utterances: Optional[List[str]] = None):
+        """Updates the route specified in name. Allows the update of
+        threshold and/or utterances. If no values are provided via the
+        threshold or utterances parameters, those fields are not updated.
+        If neither field is provided raises a ValueError.
+
+        The name must exist within the local RouteLayer, if not a
+        KeyError will be raised.
+        """
+
+        if threshold is None and utterances is None:
+            raise ValueError("At least one of 'threshold' or 'utterances' must be provided.")
+        if utterances:
+            raise NotImplementedError("The update method cannot be used for updating utterances yet.")
+        
+        route = self.get(name)
+        if route:
+            if threshold:
+                old_threshold = route.score_threshold
+                route.score_threshold = threshold
+                logger.info(f"Updated threshold for route '{route.name}' from {old_threshold} to {threshold}")
+        else:
+            raise ValueError(f"Route '{name}' not found. Nothing updated.")
 
     def delete(self, route_name: str):
         """Deletes a route given a specific route name.

--- a/tests/unit/test_layer.py
+++ b/tests/unit/test_layer.py
@@ -811,6 +811,36 @@ class TestRouteLayer:
         ):
             route_layer._refresh_routes()
 
+    def test_update_threshold(self, openai_encoder, routes, index_cls):
+        index = init_index(index_cls)
+        route_layer = RouteLayer(encoder=openai_encoder, routes=routes, index=index)
+        route_name = "Route 1"
+        new_threshold = 0.8
+        route_layer.update(name=route_name, threshold=new_threshold)
+        updated_route = route_layer.get(route_name)
+        assert updated_route.score_threshold == new_threshold, f"Expected threshold to be updated to {new_threshold}, but got {updated_route.score_threshold}"
+
+    def test_update_non_existent_route(self, openai_encoder, routes, index_cls):
+        index = init_index(index_cls)
+        route_layer = RouteLayer(encoder=openai_encoder, routes=routes, index=index)
+        non_existent_route = "Non-existent Route"
+        with pytest.raises(ValueError, match=f"Route '{non_existent_route}' not found. Nothing updated."):
+            route_layer.update(name=non_existent_route, threshold=0.7)
+
+    def test_update_without_parameters(self, openai_encoder, routes, index_cls):
+        index = init_index(index_cls)
+        route_layer = RouteLayer(encoder=openai_encoder, routes=routes, index=index)
+        with pytest.raises(ValueError, match="At least one of 'threshold' or 'utterances' must be provided."):
+            route_layer.update(name="Route 1")
+
+    def test_update_utterances_not_implemented(self, openai_encoder, routes, index_cls):
+        index = init_index(index_cls)
+        route_layer = RouteLayer(encoder=openai_encoder, routes=routes, index=index)
+        with pytest.raises(NotImplementedError, match="The update method cannot be used for updating utterances yet."):
+            route_layer.update(name="Route 1", utterances=["New utterance"])
+
+
+
 
 class TestLayerFit:
     def test_eval(self, openai_encoder, routes, test_data):
@@ -948,3 +978,4 @@ class TestLayerConfig:
             elif agg == "max":
                 assert classification == "Route 3"
                 assert score == [0.1, 1.0]
+

--- a/tests/unit/test_layer.py
+++ b/tests/unit/test_layer.py
@@ -818,28 +818,37 @@ class TestRouteLayer:
         new_threshold = 0.8
         route_layer.update(name=route_name, threshold=new_threshold)
         updated_route = route_layer.get(route_name)
-        assert updated_route.score_threshold == new_threshold, f"Expected threshold to be updated to {new_threshold}, but got {updated_route.score_threshold}"
+        assert (
+            updated_route.score_threshold == new_threshold
+        ), f"Expected threshold to be updated to {new_threshold}, but got {updated_route.score_threshold}"
 
     def test_update_non_existent_route(self, openai_encoder, routes, index_cls):
         index = init_index(index_cls)
         route_layer = RouteLayer(encoder=openai_encoder, routes=routes, index=index)
         non_existent_route = "Non-existent Route"
-        with pytest.raises(ValueError, match=f"Route '{non_existent_route}' not found. Nothing updated."):
+        with pytest.raises(
+            ValueError,
+            match=f"Route '{non_existent_route}' not found. Nothing updated.",
+        ):
             route_layer.update(name=non_existent_route, threshold=0.7)
 
     def test_update_without_parameters(self, openai_encoder, routes, index_cls):
         index = init_index(index_cls)
         route_layer = RouteLayer(encoder=openai_encoder, routes=routes, index=index)
-        with pytest.raises(ValueError, match="At least one of 'threshold' or 'utterances' must be provided."):
+        with pytest.raises(
+            ValueError,
+            match="At least one of 'threshold' or 'utterances' must be provided.",
+        ):
             route_layer.update(name="Route 1")
 
     def test_update_utterances_not_implemented(self, openai_encoder, routes, index_cls):
         index = init_index(index_cls)
         route_layer = RouteLayer(encoder=openai_encoder, routes=routes, index=index)
-        with pytest.raises(NotImplementedError, match="The update method cannot be used for updating utterances yet."):
+        with pytest.raises(
+            NotImplementedError,
+            match="The update method cannot be used for updating utterances yet.",
+        ):
             route_layer.update(name="Route 1", utterances=["New utterance"])
-
-
 
 
 class TestLayerFit:
@@ -978,4 +987,3 @@ class TestLayerConfig:
             elif agg == "max":
                 assert classification == "Route 3"
                 assert score == [0.1, 1.0]
-


### PR DESCRIPTION
### **User description**
Based on point 1 from this issue: https://github.com/aurelio-labs/semantic-router/issues/392

At the moment just altering the `RouteLayer` method `update` to allow the user to update the `Route` `score_thresholds` that are held in memory. 

Later we'll build functionality to allow for thresholds to persist remotely (e.g. in Pinecone), and to update them remotely too.

We'll also implement alteration of `utterances` for `Routes` later.


___

### **PR Type**
enhancement, error handling


___

### **Description**
- Enhanced the `update` method in `RouteLayer` to allow updating the `score_threshold` of a route directly.
- Added error handling to raise a `ValueError` if neither `threshold` nor `utterances` are provided.
- Implemented a check to raise a `KeyError` if the specified route does not exist.
- Added logging to track changes in route thresholds.
- Included a placeholder for future implementation of utterance updates, currently raising `NotImplementedError`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layer.py</strong><dd><code>Enhance route update method with threshold adjustment and error </code><br><code>handling</code></dd></summary>
<hr>

semantic_router/layer.py

<li>Enhanced the <code>update</code> method to allow updating route thresholds.<br> <li> Added error handling for missing parameters and non-existent routes.<br> <li> Implemented logging for threshold updates.<br> <li> Added a placeholder for future utterance updates.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/436/files#diff-e495ddf91e18dd7477eb129fd2c0ab7dfbaf2440534c28b6156a76acdaf51433">+23/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information