### PR TITLE
fix: pinecone version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3360,32 +3360,20 @@ xmp = ["defusedxml"]
 
 [[package]]
 name = "pinecone"
-version = "4.1.2"
+version = "5.3.1"
 description = "Pinecone client and SDK"
 optional = true
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "pinecone-4.1.2-py3-none-any.whl", hash = "sha256:5426b70f24cdbb9716ea77c9504f68a7cfe705f4a354d185781588034214085a"},
-    {file = "pinecone-4.1.2.tar.gz", hash = "sha256:9024001cba59793d04b28195268fa498593e3175e2edba648debb179b37cb1d9"},
-]
-
-[package.dependencies]
-pinecone-client = "4.1.2"
-
-[[package]]
-name = "pinecone-client"
-version = "4.1.2"
-description = "Pinecone client and SDK"
-optional = true
-python-versions = "<4.0,>=3.8"
-files = [
-    {file = "pinecone_client-4.1.2-py3-none-any.whl", hash = "sha256:3d69cbbca2d9d4f77c90bad59a1194e3d20d535b29f277eee32b439fd526546b"},
-    {file = "pinecone_client-4.1.2.tar.gz", hash = "sha256:fa89c605792ec94de36d4c9585250b47b0b643407457053eca89008424be6281"},
+    {file = "pinecone-5.3.1-py3-none-any.whl", hash = "sha256:dd180963d29cd648f2d58becf18b21f150362aef80446dd3a7ed15cbe85bb4c7"},
+    {file = "pinecone-5.3.1.tar.gz", hash = "sha256:a216630331753958f4ebcdc6e6d473402d17152f2194af3e19b3416c73b0dcc4"},
 ]
 
 [package.dependencies]
 certifi = ">=2019.11.17"
+pinecone-plugin-inference = ">=1.1.0,<2.0.0"
 pinecone-plugin-interface = ">=0.0.7,<0.0.8"
+python-dateutil = ">=2.5.3"
 tqdm = ">=4.64.1"
 typing-extensions = ">=3.7.4"
 urllib3 = [
@@ -3395,6 +3383,20 @@ urllib3 = [
 
 [package.extras]
 grpc = ["googleapis-common-protos (>=1.53.0)", "grpcio (>=1.44.0)", "grpcio (>=1.59.0)", "lz4 (>=3.1.3)", "protobuf (>=4.25,<5.0)", "protoc-gen-openapiv2 (>=0.0.1,<0.0.2)"]
+
+[[package]]
+name = "pinecone-plugin-inference"
+version = "1.1.0"
+description = "Embeddings plugin for Pinecone SDK"
+optional = true
+python-versions = "<4.0,>=3.8"
+files = [
+    {file = "pinecone_plugin_inference-1.1.0-py3-none-any.whl", hash = "sha256:32c61aba21c9a28fdcd0e782204c1ca641aeb3fd6e42764fbf0de8186eb657ec"},
+    {file = "pinecone_plugin_inference-1.1.0.tar.gz", hash = "sha256:283e5ae4590b901bf2179beb56fc3d1b715e63582f37ec7abb0708cf70912d1f"},
+]
+
+[package.dependencies]
+pinecone-plugin-interface = ">=0.0.7,<0.0.8"
 
 [[package]]
 name = "pinecone-plugin-interface"
@@ -5501,4 +5503,4 @@ vision = ["pillow", "torch", "torchvision", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "ab432636136809eac18cfcefc7abfeb66351467aa395a8644427d6e4f5beea55"
+content-hash = "3b6d8cef3e0d6c516a9d9704350e8ff6dac7277cabed851f8c4ccc84214df6ea"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ transformers = {version = ">=4.36.2", optional = true}
 tokenizers = {version = ">=0.19", optional = true}
 llama-cpp-python = {version = ">=0.2.28,<0.2.86", optional = true}
 colorama = "^0.4.6"
-pinecone = {version="<5.0.0", optional = true}
+pinecone = {version=">=5.0.0", optional = true}
 regex = ">=2023.12.25"
 torchvision = { version = ">=0.17.0,<0.18.0", optional = true}
 pillow = { version = ">=10.2.0,<11.0.0", optional = true}


### PR DESCRIPTION
### **PR Type**
dependencies


___

### **Description**
- Updated the `pinecone` dependency version in `pyproject.toml` to ensure compatibility with versions 5.0.0 and above.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Update `pinecone` dependency version in `pyproject.toml`</code>&nbsp; </dd></summary>
<hr>

pyproject.toml

<li>Updated the <code>pinecone</code> dependency version to be greater than or equal to <br>5.0.0.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/441/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information