### PR TITLE
feat: is_synced method for Pinecone Index

### DIFF
--- a/docs/source/route_layer/sync.rst
+++ b/docs/source/route_layer/sync.rst
@@ -68,3 +68,9 @@ You can try this yourself by running the following:
     rl = RouteLayer(encoder=encoder, routes=routes, index=pc_index)
 
 When initializing the `PineconeIndex` object, we can specify the `sync` parameter.
+
+Checking for Synchronization
+----------------------------
+
+To verify whether the local and remote instances are synchronized, you can use the `is_synced` method. This method checks if the routes, utterances, and associated metadata in the local instance match those stored in the remote index.
+Consider that if the `sync` flag is not set (e.g. for indexes different from Pinecone), it raises an error. If the index supports sync feature and everything aligns, it returns `True`, indicating that the local and remote instances are synchronized, otherwise it returns `False`.

--- a/semantic_router/index/base.py
+++ b/semantic_router/index/base.py
@@ -112,17 +112,17 @@ class BaseIndex(BaseModel):
 
     def is_synced(
         self,
-        local_route_names: List[str], 
-        local_utterances_list: List[str], 
-        local_function_schemas_list: List[Dict[str, Any]], 
-        local_metadata_list: List[Dict[str, Any]]
+        local_route_names: List[str],
+        local_utterances_list: List[str],
+        local_function_schemas_list: List[Dict[str, Any]],
+        local_metadata_list: List[Dict[str, Any]],
     ) -> bool:
         """
         Checks whether local and remote index are synchronized.
         This method should be implemented by subclasses.
         """
         raise NotImplementedError("This method should be implemented by subclasses.")
-    
+
     def _sync_index(
         self,
         local_route_names: List[str],

--- a/semantic_router/index/base.py
+++ b/semantic_router/index/base.py
@@ -110,6 +110,19 @@ class BaseIndex(BaseModel):
         """
         raise NotImplementedError("This method should be implemented by subclasses.")
 
+    def is_synced(
+        self,
+        local_route_names: List[str], 
+        local_utterances_list: List[str], 
+        local_function_schemas_list: List[Dict[str, Any]], 
+        local_metadata_list: List[Dict[str, Any]]
+    ) -> bool:
+        """
+        Checks whether local and remote index are synchronized.
+        This method should be implemented by subclasses.
+        """
+        raise NotImplementedError("This method should be implemented by subclasses.")
+    
     def _sync_index(
         self,
         local_route_names: List[str],

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -217,11 +217,11 @@ class PineconeIndex(BaseIndex):
 
     def _format_routes_dict_for_sync(
         self,
-        local_route_names: List[str], 
-        local_utterances_list: List[str], 
-        local_function_schemas_list: List[Dict[str, Any]], 
+        local_route_names: List[str],
+        local_utterances_list: List[str],
+        local_function_schemas_list: List[Dict[str, Any]],
         local_metadata_list: List[Dict[str, Any]],
-        remote_routes: List[Tuple]
+        remote_routes: List[Tuple],
     ) -> Tuple[Dict, Dict]:
         remote_dict: Dict[str, Dict[str, Any]] = {
             route: {
@@ -252,13 +252,13 @@ class PineconeIndex(BaseIndex):
             local_dict[route]["metadata"] = metadata
 
         return local_dict, remote_dict
-    
+
     def is_synced(
         self,
-        local_route_names: List[str], 
-        local_utterances_list: List[str], 
-        local_function_schemas_list: List[Dict[str, Any]], 
-        local_metadata_list: List[Dict[str, Any]]
+        local_route_names: List[str],
+        local_utterances_list: List[str],
+        local_function_schemas_list: List[Dict[str, Any]],
+        local_metadata_list: List[Dict[str, Any]],
     ) -> bool:
         remote_routes = self.get_routes()
 
@@ -267,7 +267,7 @@ class PineconeIndex(BaseIndex):
             local_utterances_list,
             local_function_schemas_list,
             local_metadata_list,
-            remote_routes
+            remote_routes,
         )
         logger.info(f"LOCAL: {local_dict}")
         logger.info(f"REMOTE: {remote_dict}")
@@ -292,7 +292,7 @@ class PineconeIndex(BaseIndex):
                 or local_metadata != remote_metadata
             ):
                 return False
-            
+
         return True
 
     def _sync_index(
@@ -314,7 +314,7 @@ class PineconeIndex(BaseIndex):
             local_utterances_list,
             local_function_schemas_list,
             local_metadata_list,
-            remote_routes
+            remote_routes,
         )
 
         all_routes = set(remote_dict.keys()).union(local_dict.keys())

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -215,21 +215,14 @@ class PineconeIndex(BaseIndex):
             logger.warning("Index could not be initialized.")
         self.host = index_stats["host"] if index_stats else None
 
-    def _sync_index(
+    def _format_routes_dict_for_sync(
         self,
-        local_route_names: List[str],
-        local_utterances_list: List[str],
-        local_function_schemas_list: List[Dict[str, Any]],
+        local_route_names: List[str], 
+        local_utterances_list: List[str], 
+        local_function_schemas_list: List[Dict[str, Any]], 
         local_metadata_list: List[Dict[str, Any]],
-        dimensions: int,
-    ) -> Tuple[List, List, Dict]:
-        if self.index is None:
-            self.dimensions = self.dimensions or dimensions
-            self.index = self._init_index(force_create=True)
-
-        remote_routes = self.get_routes()
-
-        # Create remote dictionary for storing utterances and metadata
+        remote_routes: List[Tuple]
+    ) -> Tuple[Dict, Dict]:
         remote_dict: Dict[str, Dict[str, Any]] = {
             route: {
                 "utterances": set(),
@@ -241,7 +234,6 @@ class PineconeIndex(BaseIndex):
         for route, utterance, function_schemas, metadata in remote_routes:
             remote_dict[route]["utterances"].add(utterance)
 
-        # Create local dictionary for storing utterances and metadata
         local_dict: Dict[str, Dict[str, Any]] = {}
         for route, utterance, function_schemas, metadata in zip(
             local_route_names,
@@ -258,6 +250,72 @@ class PineconeIndex(BaseIndex):
             local_dict[route]["utterances"].add(utterance)
             local_dict[route]["function_schemas"] = function_schemas
             local_dict[route]["metadata"] = metadata
+
+        return local_dict, remote_dict
+    
+    def is_synced(
+        self,
+        local_route_names: List[str], 
+        local_utterances_list: List[str], 
+        local_function_schemas_list: List[Dict[str, Any]], 
+        local_metadata_list: List[Dict[str, Any]]
+    ) -> bool:
+        remote_routes = self.get_routes()
+
+        local_dict, remote_dict = self._format_routes_dict_for_sync(
+            local_route_names,
+            local_utterances_list,
+            local_function_schemas_list,
+            local_metadata_list,
+            remote_routes
+        )
+        logger.info(f"LOCAL: {local_dict}")
+        logger.info(f"REMOTE: {remote_dict}")
+
+        all_routes = set(remote_dict.keys()).union(local_dict.keys())
+
+        for route in all_routes:
+            local_utterances = local_dict.get(route, {}).get("utterances", set())
+            remote_utterances = remote_dict.get(route, {}).get("utterances", set())
+            local_function_schemas = (
+                local_dict.get(route, {}).get("function_schemas", {}) or {}
+            )
+            remote_function_schemas = (
+                remote_dict.get(route, {}).get("function_schemas", {}) or {}
+            )
+            local_metadata = local_dict.get(route, {}).get("metadata", {})
+            remote_metadata = remote_dict.get(route, {}).get("metadata", {})
+
+            if (
+                local_utterances != remote_utterances
+                or local_function_schemas != remote_function_schemas
+                or local_metadata != remote_metadata
+            ):
+                return False
+            
+        return True
+
+    def _sync_index(
+        self,
+        local_route_names: List[str],
+        local_utterances_list: List[str],
+        local_function_schemas_list: List[Dict[str, Any]],
+        local_metadata_list: List[Dict[str, Any]],
+        dimensions: int,
+    ) -> Tuple[List, List, Dict]:
+        if self.index is None:
+            self.dimensions = self.dimensions or dimensions
+            self.index = self._init_index(force_create=True)
+
+        remote_routes = self.get_routes()
+
+        local_dict, remote_dict = self._format_routes_dict_for_sync(
+            local_route_names,
+            local_utterances_list,
+            local_function_schemas_list,
+            local_metadata_list,
+            remote_routes
+        )
 
         all_routes = set(remote_dict.keys()).union(local_dict.keys())
 

--- a/semantic_router/layer.py
+++ b/semantic_router/layer.py
@@ -529,12 +529,14 @@ class RouteLayer:
     def is_synced(self) -> bool:
         if not self.index.sync:
             raise ValueError("Index is not set to sync with remote index.")
-        
+
         local_route_names, local_utterances, local_function_schemas, local_metadata = (
             self._extract_routes_details(self.routes, include_metadata=True)
         )
-        return self.index.is_synced(local_route_names, local_utterances, local_function_schemas, local_metadata)
-                
+        return self.index.is_synced(
+            local_route_names, local_utterances, local_function_schemas, local_metadata
+        )
+
     def _add_and_sync_routes(self, routes: List[Route]):
         # create embeddings for all routes and sync at startup with remote ones based on sync setting
         local_route_names, local_utterances, local_function_schemas, local_metadata = (

--- a/semantic_router/layer.py
+++ b/semantic_router/layer.py
@@ -526,6 +526,15 @@ class RouteLayer:
             logger.error(f"Failed to add routes to the index: {e}")
             raise Exception("Indexing error occurred") from e
 
+    def is_synced(self) -> bool:
+        if not self.index.sync:
+            raise ValueError("Index is not set to sync with remote index.")
+        
+        local_route_names, local_utterances, local_function_schemas, local_metadata = (
+            self._extract_routes_details(self.routes, include_metadata=True)
+        )
+        return self.index.is_synced(local_route_names, local_utterances, local_function_schemas, local_metadata)
+                
     def _add_and_sync_routes(self, routes: List[Route]):
         # create embeddings for all routes and sync at startup with remote ones based on sync setting
         local_route_names, local_utterances, local_function_schemas, local_metadata = (


### PR DESCRIPTION
### **User description**
Related to issue #443 
Added is_synced method in Pinecone index and route layer that is checking if local and remote index are currently synced and return True if so, otherwise it returns False.


___

### **PR Type**
enhancement


___

### **Description**
- Introduced `is_synced` method in the base index class to check synchronization between local and remote indexes.
- Implemented `is_synced` method in the Pinecone index to compare local and remote data, ensuring they are synchronized.
- Refactored the synchronization logic to improve code clarity and maintainability.
- Added logging to provide insights into the synchronization process by displaying local and remote dictionaries.
- Enhanced the route layer with an `is_synced` method to verify synchronization status, raising an error if the index is not set to sync.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.py</strong><dd><code>Add `is_synced` method to base index class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/index/base.py

<li>Added <code>is_synced</code> method to check synchronization between local and <br>remote indexes.<br> <li> Method raises <code>NotImplementedError</code>, indicating it should be implemented <br>by subclasses.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/444/files#diff-df154312e842c3302d871397cc51942d0a6e3be19183c0b362499fb8e2fcd127">+13/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pinecone.py</strong><dd><code>Implement `is_synced` method for Pinecone index</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/index/pinecone.py

<li>Implemented <code>is_synced</code> method to compare local and remote index data.<br> <li> Refactored <code>_sync_index</code> to use <code>_format_routes_dict_for_sync</code>.<br> <li> Added logging for local and remote dictionaries.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/444/files#diff-c57f54339773ad317ee6eafd071395202933f9eeaf59a10c28fc22d06bf564a2">+69/-11</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>layer.py</strong><dd><code>Add `is_synced` method to route layer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/layer.py

<li>Added <code>is_synced</code> method to check if the index is synchronized.<br> <li> Raises <code>ValueError</code> if index is not set to sync.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/444/files#diff-e495ddf91e18dd7477eb129fd2c0ab7dfbaf2440534c28b6156a76acdaf51433">+11/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information