### PR TITLE
fix: function schemas

### DIFF
--- a/docs/indexes/pinecone-sync-routes.ipynb
+++ b/docs/indexes/pinecone-sync-routes.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -qU \"semantic-router[pinecone]==0.1.0.dev0\""
+    "!pip install -qU \"semantic-router[pinecone]==0.1.0.dev1\""
    ]
   },
   {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.abspath("../.."))  # Source code dir relative to this
 project = "Semantic Router"
 copyright = "2024, Aurelio AI"
 author = "Aurelio AI"
-release = "0.1.0.dev0"
+release = "0.1.0.dev1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "semantic-router"
-version = "0.1.0.dev0"
+version = "0.1.0.dev1"
 description = "Super fast semantic router for AI decision making"
 authors = ["Aurelio AI <hello@aurelio.ai>"]
 readme = "README.md"

--- a/semantic_router/__init__.py
+++ b/semantic_router/__init__.py
@@ -4,4 +4,4 @@ from semantic_router.route import Route
 
 __all__ = ["RouteLayer", "HybridRouteLayer", "Route", "LayerConfig"]
 
-__version__ = "0.1.0.dev0"
+__version__ = "0.1.0.dev1"

--- a/semantic_router/layer.py
+++ b/semantic_router/layer.py
@@ -488,7 +488,7 @@ class RouteLayer:
             remote_utterances=remote_utterances,
         )
         # generate sync strategy
-        sync_strategy = diff.to_sync_strategy()
+        sync_strategy = diff.get_sync_strategy(sync_mode=sync_mode)
         # and execute
         self._execute_sync_strategy(sync_strategy)
         return diff.to_utterance_str()

--- a/semantic_router/schema.py
+++ b/semantic_router/schema.py
@@ -98,6 +98,8 @@ class Utterance(BaseModel):
         """
         route, utterance = tuple_obj[0], tuple_obj[1]
         function_schemas = tuple_obj[2] if len(tuple_obj) > 2 else None
+        if isinstance(function_schemas, dict):
+            function_schemas = [function_schemas]
         metadata = tuple_obj[3] if len(tuple_obj) > 3 else {}
         return cls(
             route=route,

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -389,7 +389,7 @@ class TestRouteLayer:
             encoder=openai_encoder,
             routes=[],
             index=init_index(index_cls),
-            sync=None,
+            auto_sync=None,
         )
         route_layer.sync("remote")
         time.sleep(PINECONE_SLEEP)  # allow for index to be populated

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -384,6 +384,21 @@ class TestRouteLayer:
     @pytest.mark.skipif(
         os.environ.get("PINECONE_API_KEY") is None, reason="Pinecone API key required"
     )
+    def test_sync(self, openai_encoder, index_cls):
+        route_layer = RouteLayer(
+            encoder=openai_encoder,
+            routes=[],
+            index=init_index(index_cls),
+            sync=None,
+        )
+        route_layer.sync("remote")
+        time.sleep(PINECONE_SLEEP)  # allow for index to be populated
+        # confirm local and remote are synced
+        assert route_layer.is_synced()
+
+    @pytest.mark.skipif(
+        os.environ.get("PINECONE_API_KEY") is None, reason="Pinecone API key required"
+    )
     def test_auto_sync_merge(self, openai_encoder, routes, routes_2, index_cls):
         if index_cls is PineconeIndex:
             # TEST MERGE


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the function schemas handling in `from_tuple` method by ensuring `function_schemas` is a list, even if initially provided as a dictionary.
- Updated the sync strategy method call to use `get_sync_strategy` with the `sync_mode` parameter in `sync` method.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layer.py</strong><dd><code>Update sync strategy method call with parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/layer.py

<li>Changed method call from <code>to_sync_strategy</code> to <code>get_sync_strategy</code> with <br><code>sync_mode</code> parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/463/files#diff-e495ddf91e18dd7477eb129fd2c0ab7dfbaf2440534c28b6156a76acdaf51433">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>schema.py</strong><dd><code>Fix function schemas handling in from_tuple method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/schema.py

<li>Added check for <code>function_schemas</code> to convert dict to list if necessary.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/463/files#diff-2745f608339614a7c34abdc5917e375f87cb4c953a07404ed96f4f37180b3232">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information