### PR TITLE
fix: sort func schemas and metadata in diffs

### DIFF
--- a/semantic_router/schema.py
+++ b/semantic_router/schema.py
@@ -130,12 +130,12 @@ class Utterance(BaseModel):
             # we sort the dicts to ensure consistent order as we need this to compare
             # stringified function schemas accurately
             if self.function_schemas is not None:
-                function_schemas_sorted = [
+                function_schemas_sorted: List[str] | None = [
                     json.dumps(schema, sort_keys=True)
                     for schema in self.function_schemas
                 ]
             else:
-                function_schemas_sorted = []
+                function_schemas_sorted = None
             # we must do the same for metadata
             metadata_sorted = json.dumps(self.metadata, sort_keys=True)
             return f"{self.route}: {self.utterance} | {function_schemas_sorted} | {metadata_sorted}"

--- a/semantic_router/schema.py
+++ b/semantic_router/schema.py
@@ -134,6 +134,8 @@ class Utterance(BaseModel):
                     json.dumps(schema, sort_keys=True)
                     for schema in self.function_schemas
                 ]
+            else:
+                function_schemas_sorted = []
             # we must do the same for metadata
             metadata_sorted = json.dumps(self.metadata, sort_keys=True)
             return f"{self.route}: {self.utterance} | {function_schemas_sorted} | {metadata_sorted}"

--- a/semantic_router/schema.py
+++ b/semantic_router/schema.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from difflib import Differ
 from enum import Enum
+import json
 import numpy as np
 from typing import List, Optional, Union, Any, Dict, Tuple
 from pydantic import BaseModel, Field
@@ -126,7 +127,15 @@ class Utterance(BaseModel):
 
     def to_str(self, include_metadata: bool = False):
         if include_metadata:
-            return f"{self.route}: {self.utterance} | {self.function_schemas} | {self.metadata}"
+            # we sort the dicts to ensure consistent order as we need this to compare
+            # stringified function schemas accurately
+            function_schemas_sorted = [
+                json.dumps(schema, sort_keys=True)
+                for schema in self.function_schemas
+            ]
+            # we must do the same for metadata
+            metadata_sorted = json.dumps(self.metadata, sort_keys=True)
+            return f"{self.route}: {self.utterance} | {function_schemas_sorted} | {metadata_sorted}"
         return f"{self.route}: {self.utterance}"
 
     def to_diff_str(self, include_metadata: bool = False):

--- a/semantic_router/schema.py
+++ b/semantic_router/schema.py
@@ -129,10 +129,11 @@ class Utterance(BaseModel):
         if include_metadata:
             # we sort the dicts to ensure consistent order as we need this to compare
             # stringified function schemas accurately
-            function_schemas_sorted = [
-                json.dumps(schema, sort_keys=True)
-                for schema in self.function_schemas
-            ]
+            if self.function_schemas is not None:
+                function_schemas_sorted = [
+                    json.dumps(schema, sort_keys=True)
+                    for schema in self.function_schemas
+                ]
             # we must do the same for metadata
             metadata_sorted = json.dumps(self.metadata, sort_keys=True)
             return f"{self.route}: {self.utterance} | {function_schemas_sorted} | {metadata_sorted}"

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -283,8 +283,8 @@ class TestSemanticRouter:
         if index_cls is PineconeIndex:
             time.sleep(PINECONE_SLEEP)  # allow for index to be populated
         diff = route_layer_2.get_utterance_diff(include_metadata=True)
-        assert "+ Route 1: Hello | None | {'type': 'default'}" in diff
-        assert "+ Route 1: Hi | None | {'type': 'default'}" in diff
+        assert '+ Route 1: Hello | None | {"type": "default"}' in diff
+        assert '+ Route 1: Hi | None | {"type": "default"}' in diff
         assert "- Route 1: Hello | None | {}" in diff
         assert "+ Route 2: Au revoir | None | {}" in diff
         assert "- Route 2: Hi | None | {}" in diff


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue with inconsistent ordering in function schemas and metadata by sorting them before stringification.
- Ensured accurate comparison of stringified function schemas and metadata by using sorted keys.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.py</strong><dd><code>Sort function schemas and metadata for consistent diffs</code>&nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/schema.py

<li>Added sorting for <code>function_schemas</code> and <code>metadata</code> using <code>json.dumps</code> with <br><code>sort_keys=True</code>.<br> <li> Ensured consistent order for stringified function schemas and metadata <br>for accurate comparison.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/473/files#diff-2745f608339614a7c34abdc5917e375f87cb4c953a07404ed96f4f37180b3232">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information