### PR TITLE
fix: missing auto_sync in intro doc

### DIFF
--- a/docs/00-introduction.ipynb
+++ b/docs/00-introduction.ipynb
@@ -189,7 +189,7 @@
       "source": [
         "from semantic_router.routers import SemanticRouter\n",
         "\n",
-        "sr = SemanticRouter(encoder=encoder, routes=routes)"
+        "sr = SemanticRouter(encoder=encoder, routes=routes, auto_sync="local")"
       ]
     },
     {

--- a/docs/00-introduction.ipynb
+++ b/docs/00-introduction.ipynb
@@ -189,7 +189,7 @@
       "source": [
         "from semantic_router.routers import SemanticRouter\n",
         "\n",
-        "sr = SemanticRouter(encoder=encoder, routes=routes, auto_sync="local")"
+        "sr = SemanticRouter(encoder=encoder, routes=routes, auto_sync=\"local\")"
       ]
     },
     {


### PR DESCRIPTION
### **PR Type**
documentation


___

### **Description**
- Updated the introductory documentation in `docs/00-introduction.ipynb` to include the missing `auto_sync` parameter in the `SemanticRouter` instantiation example.
- Ensures the example code is accurate and aligns with the expected usage of the `SemanticRouter` class.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>00-introduction.ipynb</strong><dd><code>Add `auto_sync` parameter to `SemanticRouter` example in introduction</code></dd></summary>
<hr>

docs/00-introduction.ipynb

<li>Added the <code>auto_sync</code> parameter to the <code>SemanticRouter</code> instantiation <br>example.<br> <li> Updated the introductory documentation to include the missing <br>parameter for clarity.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/476/files#diff-21491e5b61c76430cdaa72c7efd5fe297e3128ea10845545e116fe59ff0e4056">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information