### PR TITLE
feat: add test for single route single utterance

### DIFF
--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -152,7 +152,7 @@ def routes_4():
 @pytest.fixture
 def route_single_utterance():
     return [
-        Route(name="Route 1", utterances=["Hello"]),
+        Route(name="Route 3", utterances=["Hello"]),
     ]
 
 
@@ -259,11 +259,12 @@ class TestSemanticRouter:
         assert route_layer.score_threshold == openai_encoder.score_threshold
 
     def test_add_single_utterance(
-        self, route_single_utterance, openai_encoder, index_cls
+        self, routes, route_single_utterance, openai_encoder, index_cls
     ):
         index = init_index(index_cls)
         route_layer = SemanticRouter(
             encoder=openai_encoder,
+            routes=routes,
             index=index,
             auto_sync="local",
         )

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -148,11 +148,13 @@ def routes_4():
         Route(name="Route 2", utterances=["Asparagus"]),
     ]
 
+
 @pytest.fixture
 def route_single_utterance():
     return [
         Route(name="Route 1", utterances=["Hello"]),
     ]
+
 
 @pytest.fixture
 def dynamic_routes():

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -258,16 +258,16 @@ class TestSemanticRouter:
         )
         assert route_layer.score_threshold == openai_encoder.score_threshold
 
-    def test_initialization_single_utterance(
+    def test_add_single_utterance(
         self, route_single_utterance, openai_encoder, index_cls
     ):
         index = init_index(index_cls)
         route_layer = SemanticRouter(
             encoder=openai_encoder,
-            routes=route_single_utterance,
             index=index,
             auto_sync="local",
         )
+        route_layer.add(routes=[route_single_utterance])
         assert route_layer.score_threshold == openai_encoder.score_threshold
         if index_cls is PineconeIndex:
             time.sleep(PINECONE_SLEEP)  # allow for index to be updated

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -272,6 +272,23 @@ class TestSemanticRouter:
         assert route_layer.score_threshold == openai_encoder.score_threshold
         if index_cls is PineconeIndex:
             time.sleep(PINECONE_SLEEP)  # allow for index to be updated
+        _ = route_layer("Hello")
+        assert len(route_layer.index.get_utterances()) == 6
+
+    def test_init_and_add_single_utterance(
+        self, route_single_utterance, openai_encoder, index_cls
+    ):
+        index = init_index(index_cls)
+        route_layer = SemanticRouter(
+            encoder=openai_encoder,
+            index=index,
+            auto_sync="local",
+        )
+        if index_cls is PineconeIndex:
+            time.sleep(PINECONE_SLEEP)  # allow for index to be updated
+        route_layer.add(routes=[route_single_utterance])
+        assert route_layer.score_threshold == openai_encoder.score_threshold
+        _ = route_layer("Hello")
         assert len(route_layer.index.get_utterances()) == 1
 
     def test_delete_index(self, openai_encoder, routes, index_cls):

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -148,6 +148,11 @@ def routes_4():
         Route(name="Route 2", utterances=["Asparagus"]),
     ]
 
+@pytest.fixture
+def route_single_utterance():
+    return [
+        Route(name="Route 1", utterances=["Hello"]),
+    ]
 
 @pytest.fixture
 def dynamic_routes():
@@ -250,6 +255,21 @@ class TestSemanticRouter:
             auto_sync="local",
         )
         assert route_layer.score_threshold == openai_encoder.score_threshold
+
+    def test_initialization_single_utterance(
+        self, route_single_utterance, openai_encoder, index_cls
+    ):
+        index = init_index(index_cls)
+        route_layer = SemanticRouter(
+            encoder=openai_encoder,
+            routes=route_single_utterance,
+            index=index,
+            auto_sync="local",
+        )
+        assert route_layer.score_threshold == openai_encoder.score_threshold
+        if index_cls is PineconeIndex:
+            time.sleep(PINECONE_SLEEP)  # allow for index to be updated
+        assert len(route_layer.index.get_utterances()) == 1
 
     def test_delete_index(self, openai_encoder, routes, index_cls):
         # TODO merge .delete_index() and .delete_all() and get working


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Added a new pytest fixture `route_single_utterance` to provide a single route with one utterance for testing purposes.
- Implemented a new test `test_initialization_single_utterance` to verify the behavior of `SemanticRouter` when initialized with a single utterance route.
- The test ensures the correct score threshold is set and validates the number of utterances in the index.
- Included a conditional sleep for PineconeIndex to allow index updates during the test.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_router.py</strong><dd><code>Add test for single route with single utterance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_router.py

<li>Added a new pytest fixture <code>route_single_utterance</code> for a single route <br>with one utterance.<br> <li> Introduced a new test method <code>test_initialization_single_utterance</code> to <br>validate the initialization of a single utterance route in <br><code>SemanticRouter</code>.<br> <li> Ensured the test checks the score threshold and the number of <br>utterances in the index.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/488/files#diff-68d2964608cb9c8cbb97f888938b8aaf50062b04354365240181151a24608d0b">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information