### PR TITLE
fix: Fixed namespace missing in _async_fetch_metadata inside Pinecone

### DIFF
--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -654,7 +654,7 @@ class PineconeIndex(BaseIndex):
         }
 
         if self.namespace:
-            params["namespace"] = self.namespace
+            params["namespace"] = [self.namespace]
 
         headers = {
             "Api-Key": self.api_key,

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -653,6 +653,9 @@ class PineconeIndex(BaseIndex):
             "ids": [vector_id],
         }
 
+        if self.namespace:
+            params["namespace"] = self.namespace
+
         headers = {
             "Api-Key": self.api_key,
         }


### PR DESCRIPTION
### **User description**
Fixed missing namespace param inside the request for getting all routes asynchronously with PineconeIndex


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue where the `namespace` parameter was missing in the `_async_fetch_metadata` method of the Pinecone integration.
- Added logic to include the `namespace` parameter in the request if it is defined.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pinecone.py</strong><dd><code>Fix missing `namespace` parameter in `_async_fetch_metadata` method</code></dd></summary>
<hr>

semantic_router/index/pinecone.py

<li>Added a check for <code>self.namespace</code> in the <code>_async_fetch_metadata</code> method.<br> <li> Included the <code>namespace</code> parameter in the request if it exists.<br>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/490/files#diff-c57f54339773ad317ee6eafd071395202933f9eeaf59a10c28fc22d06bf564a2">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information