### PR TITLE
feat: allow optional injection of custom Pinecone client

### DIFF
--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -129,9 +129,9 @@ class PineconeIndex(BaseIndex):
         namespace: Optional[str] = "",
         base_url: Optional[str] = "https://api.pinecone.io",
         init_async_index: bool = False,
+        client: "pinecone.Pinecone" = None,
     ):
         super().__init__()
-        self.api_key = api_key or os.getenv("PINECONE_API_KEY")
         if not self.api_key:
             raise ValueError("Pinecone API key is required.")
         self.headers = {
@@ -160,7 +160,9 @@ class PineconeIndex(BaseIndex):
         if self.api_key is None:
             raise ValueError("Pinecone API key is required.")
 
-        self.client = self._initialize_client(api_key=self.api_key)
+        if not client:
+            client = self._initialize_client(api_key=self.api_key)
+        self.client = client
 
         # try initializing index
         self.index = self._init_index()


### PR DESCRIPTION
- Add a new `client` parameter to `PineconeIndex.__init__` for dependency injection.
- Use the supplied client if provided, otherwise initialize a new Pinecone client.
- Maintain backward compatibility while improving testability and configuration flexibility.
- removing duplication on api_key

Fixes #525