### PR TITLE
feat: add note on top_k to migration doc

### DIFF
--- a/docs/user-guide/guides/migration-to-v1.md
+++ b/docs/user-guide/guides/migration-to-v1.md
@@ -44,7 +44,7 @@ The v0.1 release of semantic router introduces several breaking changes to impro
   query_results = semantic_router._query(query_text)
   multiple_routes = semantic_router._semantic_classify_multiple_routes(query_results)
   
-  # After (v0.1.4+)
+  # After (v0.1.3+)
   semantic_router = SemanticRouter(encoder=encoder, routes=routes, auto_sync="local")
   # Return all routes that pass their score thresholds
   all_routes = semantic_router(query_text, limit=None)
@@ -58,6 +58,14 @@ The v0.1 release of semantic router introduces several breaking changes to impro
   
   When `limit=1` (the default), a single `RouteChoice` object is returned.
   When `limit=None` or `limit > 1`, a list of `RouteChoice` objects is returned.
+
+  > **Important Note About `top_k`**: The `top_k` parameter (default: 5) can still limit the number of routes returned, regardless of the `limit` parameter. When using `limit > 1`, we recommend setting `top_k` to a higher value such as 100 or more. If you're using `limit=None` to get all possible results, make sure to set `top_k` to be equal to or greater than the total number of utterances shared across all of your routes.
+  >
+  > ```python
+  > # Example: Setting top_k higher when retrieving multiple routes
+  > semantic_router = SemanticRouter(encoder=encoder, routes=routes, top_k=100)
+  > all_routes = semantic_router(query_text, limit=None)
+  > ```
 
 ### Synchronization Strategy
 


### PR DESCRIPTION
### **PR Type**
- Documentation



___

### **Description**
- Corrected version tag in migration instructions.

- Added note about top_k parameter impact.

- Provided example demonstrating top_k usage.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>migration-to-v1.md</strong><dd><code>Fix version comment and add top_k parameter note.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/user-guide/guides/migration-to-v1.md

<li>Updated version comment from v0.1.4+ to v0.1.3+.<br> <li> Inserted an important note regarding top_k parameter usage.<br> <li> Added code snippet demonstrating proper top_k configuration.


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/569/files#diff-d9ba58126329a13178ebdc67dfb2c923ba9d103294776df7a608295412db6b43">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>