### PR TITLE
fix: pg get utterances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ venv/
 /.vscode
 .vscode
 .idea
+.conda
 **/__pycache__
 **/*.py[cod]
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Assign `self.index` to fix get_utterances reference

- Add `_create_route_index` for B-tree on `route`

- Add `_create_index` for HNSW vector indexes

- Call new index methods in `setup_index`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postgres.py</strong><dd><code>Implement Postgres index creation methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/index/postgres.py

<li>Set <code>self.index = self</code> in constructor<br> <li> Invoke <code>_create_route_index</code> and <code>_create_index</code> in <code>setup_index</code><br> <li> Implement <code>_create_route_index</code> for <code>route</code> column<br> <li> Implement <code>_create_index</code> for HNSW on <code>vector</code> per metric


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/587/files#diff-01032ae019fc271b0b8f1c00c1ff48e9691b1c1c89dceeaa1334620fe5485e49">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>