### PR TITLE
docs(notebook): Refactor RouteLayer to SemanticRouter across documentation and examples

### DIFF
--- a/docs/encoders/bedrock.ipynb
+++ b/docs/encoders/bedrock.ipynb
@@ -1161,12 +1161,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we define the `RouteLayer`. When called, the route layer will consume text (a query) and output the category (`Route`) it belongs to — to initialize a `RouteLayer` we need our `encoder` model and a list of `routes`."
+    "Now we define the `SemanticRouter`. When called, the semantic router will consume text (a query) and output the category (`Route`) it belongs to — to initialize a `SemanticRouter` we need our `encoder` model and a list of `routes`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1178,9 +1178,9 @@
     }
    ],
    "source": [
-    "from semantic_router.layer import RouteLayer\n",
+    "from semantic_router.routers import SemanticRouter\n",
     "\n",
-    "rl = RouteLayer(encoder=encoder, routes=routes)"
+    "rl = SemanticRouter(encoder=encoder, routes=routes)"
    ]
   },
   {

--- a/docs/encoders/vision-transformer.ipynb
+++ b/docs/encoders/vision-transformer.ipynb
@@ -140,7 +140,7 @@
    "id": "02dffb37-be54-41c5-af85-56eef549d08b",
    "metadata": {},
    "source": [
-    "As with other examples, we will go ahead and define a `RouteLayer` which can be used to route between multiple routes.\n",
+    "As with other examples, we will go ahead and define a `SemanticRouter` which can be used to route between multiple routes.\n",
     "\n",
     "> ! Note: Since we're only interested in 1 class here (Shrek or not Shrek), we will only have 1 route\n",
     "\n",
@@ -149,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "98f1e057-e619-4877-9195-a980a08b8b80",
    "metadata": {},
    "outputs": [
@@ -162,9 +162,9 @@
     }
    ],
    "source": [
-    "from semantic_router.layer import RouteLayer\n",
+    "from semantic_router.routers import SemanticRouter\n",
     "\n",
-    "rl = RouteLayer(encoder=encoder, routes=routes)"
+    "rl = SemanticRouter(encoder=encoder, routes=routes)"
    ]
   },
   {

--- a/docs/examples/ollama-local-execution.ipynb
+++ b/docs/examples/ollama-local-execution.ipynb
@@ -109,14 +109,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from semantic_router.layer import RouteLayer\n",
+    "from semantic_router.routers import SemanticRouter\n",
     "from semantic_router.llms.ollama import OllamaLLM\n",
     "\n",
     "\n",
     "llm = OllamaLLM(\n",
     "    llm_name=\"openhermes\"\n",
     ")  # Change llm_name if you want to use a different LLM with dynamic routes.\n",
-    "rl = RouteLayer(encoder=encoder, routes=routes, llm=llm)"
+    "rl = SemanticRouter(encoder=encoder, routes=routes, llm=llm)"
    ]
   },
   {

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -68,12 +68,12 @@ encoder = OpenAIEncoder()
 
 ## Creating a RouteLayer
 
-With our `routes` and `encoder` defined we now create a `RouteLayer`. The RouteLayer is the decision-making engine that compares incoming text against your routes to find the best semantic match.
+With our `routes` and `encoder` defined we now create a `SemanticRouter`. The SemanticRouter is the decision-making engine that compares incoming text against your routes to find the best semantic match.
 
 ```python
-from semantic_router.layer import RouteLayer
+from semantic_router.routers import SemanticRouter
 
-rl = RouteLayer(encoder=encoder, routes=routes)
+rl = SemanticRouter(encoder=encoder, routes=routes)
 ```
 
 ## Making Routing Decisions

--- a/docs/indexes/pinecone-async.ipynb
+++ b/docs/indexes/pinecone-async.ipynb
@@ -229,18 +229,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `RouteLayer` class supports both sync and async operations by default, so we initialize as usual:"
+    "The `SemanticRouter` class supports both sync and async operations by default, so we initialize as usual:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from semantic_router.layer import RouteLayer\n",
+    "from semantic_router.routers import SemanticRouter\n",
     "\n",
-    "rl = RouteLayer(encoder=encoder, routes=routes, index=pc_index)"
+    "rl = SemanticRouter(encoder=encoder, routes=routes, index=pc_index)"
    ]
   },
   {

--- a/docs/indexes/postgres/postgres.ipynb
+++ b/docs/indexes/postgres/postgres.ipynb
@@ -106,15 +106,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Import the RouteLayer class\n",
-    "from semantic_router.layer import RouteLayer\n",
+    "# Import the SemanticRouter class\n",
+    "from semantic_router.routers import SemanticRouter\n",
     "\n",
-    "# Initialize the RouteLayer with the encoder, routes, and index\n",
-    "rl = RouteLayer(encoder=encoder, routes=routes, index=postgres_index)"
+    "# Initialize the SemanticRouter with the encoder, routes, and index\n",
+    "rl = SemanticRouter(encoder=encoder, routes=routes, index=postgres_index)"
    ]
   },
   {

--- a/docs/indexes/qdrant.ipynb
+++ b/docs/indexes/qdrant.ipynb
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -88,9 +88,9 @@
     }
    ],
    "source": [
-    "from semantic_router.layer import RouteLayer\n",
+    "from semantic_router.routers import SemanticRouter\n",
     "\n",
-    "rl = RouteLayer(encoder=encoder, routes=routes, index=qd_index)"
+    "rl = SemanticRouter(encoder=encoder, routes=routes, index=qd_index)"
    ]
   },
   {


### PR DESCRIPTION
## User description

Refactor RouteLayer to SemanticRouter across all documentation and examples.
Each notebook now uses the SemanticRouter structure consistently.

## PR Type

  - Documentation

## Description

 - Updated all references from RouteLayer to SemanticRouter in multiple notebooks.

 - Adjusted import statements to reflect new SemanticRouter structure.

