### PR TITLE
fix: sim score

### DIFF
--- a/semantic_router/routers/base.py
+++ b/semantic_router/routers/base.py
@@ -724,6 +724,8 @@ class BaseRouter(BaseModel):
                         route.llm = self.llm
                 # TODO need to move to asyncio tasks and gather
                 route_choice = await route.acall(query=text)
+                if route_choice is not None and route_choice.similarity_score is None:
+                    route_choice.similarity_score = total_score
                 passed_routes.append(route_choice)
             elif passed and route is not None and simulate_static:
                 passed_routes.append(


### PR DESCRIPTION
### **User description**
This pull request makes a small but important change to the `_async_pass_routes` method in `semantic_router/routers/base.py`. It ensures that a `similarity_score` is assigned to a `route_choice` if it is not already set, improving the handling of route scoring logic.

* [`semantic_router/routers/base.py`](diffhunk://#diff-5469c6c5b738ad6af8b68ff6868e721a3c5577af16c299ece5241354e7e41035R727-R728): Added a conditional check to assign `total_score` to `route_choice.similarity_score` if it is `None`, ensuring consistent scoring logic.


___

### **PR Type**
Bug fix


___

### **Description**
- Guard against `None` route_choice before scoring

- Assign `total_score` to missing similarity_score


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.py</strong><dd><code>Assign default similarity_score when missing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/routers/base.py

<li>Added guard to check <code>route_choice</code> is not None<br> <li> Assign <code>total_score</code> when <code>similarity_score</code> is None


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/591/files#diff-5469c6c5b738ad6af8b68ff6868e721a3c5577af16c299ece5241354e7e41035">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>