### PR TITLE
fix: add limit to acall and fix async hybrid router

### DIFF
--- a/semantic_router/routers/base.py
+++ b/semantic_router/routers/base.py
@@ -755,6 +755,7 @@ class BaseRouter(BaseModel):
         self,
         text: Optional[str] = None,
         vector: Optional[List[float] | np.ndarray] = None,
+        limit: int | None = 1,
         simulate_static: bool = False,
         route_filter: Optional[List[str]] = None,
     ) -> RouteChoice | list[RouteChoice]:
@@ -794,7 +795,7 @@ class BaseRouter(BaseModel):
             scored_routes=scored_routes,
             simulate_static=simulate_static,
             text=text,
-            limit=1,
+            limit=limit,
         )
 
     def _index_ready(self) -> bool:

--- a/semantic_router/routers/base.py
+++ b/semantic_router/routers/base.py
@@ -639,6 +639,8 @@ class BaseRouter(BaseModel):
                         route.llm = self.llm
                 # call dynamic route to generate the function_call content
                 route_choice = route(query=text)
+                if route_choice is not None and route_choice.similarity_score is None:
+                    route_choice.similarity_score = total_score
                 passed_routes.append(route_choice)
             elif passed and route is not None and simulate_static:
                 passed_routes.append(

--- a/semantic_router/routers/hybrid.py
+++ b/semantic_router/routers/hybrid.py
@@ -91,7 +91,7 @@ class HybridRouter(BaseRouter):
         """Add a route to the local HybridRouter and index.
 
         :param route: The route to add.
-        :type route: Route 
+        :type route: Route
         """
 
         if self.sparse_encoder is None:
@@ -359,7 +359,7 @@ class HybridRouter(BaseRouter):
             limit=limit,
         )
         return route_choices
-    
+
     async def acall(
         self,
         text: Optional[str] = None,
@@ -396,8 +396,7 @@ class HybridRouter(BaseRouter):
             if text is None:
                 raise ValueError("Either text or vector must be provided")
             vector, potential_sparse_vector = await self._async_encode(
-                text=[text],
-                input_type="queries"
+                text=[text], input_type="queries"
             )
         # convert to numpy array if not already
         vector = xq_reshape(xq=vector)

--- a/semantic_router/routers/hybrid.py
+++ b/semantic_router/routers/hybrid.py
@@ -91,7 +91,7 @@ class HybridRouter(BaseRouter):
         """Add a route to the local HybridRouter and index.
 
         :param route: The route to add.
-        :type route: Route
+        :type route: Route 
         """
 
         if self.sparse_encoder is None:
@@ -319,7 +319,7 @@ class HybridRouter(BaseRouter):
         if not self.index.is_ready():
             raise ValueError("Index is not ready.")
         if self.sparse_encoder is None:
-            raise ValueError
+            raise ValueError("Sparse encoder is not set.")
         potential_sparse_vector: List[SparseEmbedding] | None = None
         # if no vector provided, encode text to get vector
         if vector is None:
@@ -359,6 +359,71 @@ class HybridRouter(BaseRouter):
             limit=limit,
         )
         return route_choices
+    
+    async def acall(
+        self,
+        text: Optional[str] = None,
+        vector: Optional[List[float] | np.ndarray] = None,
+        limit: int | None = 1,
+        simulate_static: bool = False,
+        route_filter: Optional[List[str]] = None,
+        sparse_vector: dict[int, float] | SparseEmbedding | None = None,
+    ) -> RouteChoice | list[RouteChoice]:
+        """Asynchronously call the router to get a route choice.
+
+        :param text: The text to route.
+        :type text: Optional[str]
+        :param vector: The vector to route.
+        :type vector: Optional[List[float] | np.ndarray]
+        :param simulate_static: Whether to simulate a static route (ie avoid dynamic route
+            LLM calls during fit or evaluate).
+        :type simulate_static: bool
+        :param route_filter: The route filter to use.
+        :type route_filter: Optional[List[str]]
+        :param sparse_vector: The sparse vector to use.
+        :type sparse_vector: dict[int, float] | SparseEmbedding | None
+        :return: The route choice.
+        :rtype: RouteChoice
+        """
+        if not self.index.is_ready():
+            # TODO: need async version for qdrant
+            raise ValueError("Index is not ready.")
+        if self.sparse_encoder is None:
+            raise ValueError("Sparse encoder is not set.")
+        potential_sparse_vector: List[SparseEmbedding] | None = None
+        # if no vector provided, encode text to get vector
+        if vector is None:
+            if text is None:
+                raise ValueError("Either text or vector must be provided")
+            vector, potential_sparse_vector = await self._async_encode(
+                text=[text],
+                input_type="queries"
+            )
+        # convert to numpy array if not already
+        vector = xq_reshape(xq=vector)
+        if sparse_vector is None:
+            if text is None:
+                raise ValueError("Either text or sparse_vector must be provided")
+            sparse_vector = (
+                potential_sparse_vector[0] if potential_sparse_vector else None
+            )
+        # get scores and routes
+        scores, routes = await self.index.aquery(
+            vector=vector[0],
+            top_k=self.top_k,
+            route_filter=route_filter,
+            sparse_vector=sparse_vector,
+        )
+        query_results = [
+            {"route": d, "score": s.item()} for d, s in zip(routes, scores)
+        ]
+        scored_routes = self._score_routes(query_results=query_results)
+        return await self._async_pass_routes(
+            scored_routes=scored_routes,
+            simulate_static=simulate_static,
+            text=text,
+            limit=limit,
+        )
 
     def _convex_scaling(
         self, dense: np.ndarray, sparse: list[SparseEmbedding]

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -644,7 +644,9 @@ class TestHybridRouter:
         else:
             assert sparse_call_spy.called
 
-    def test_limit_parameter(self, routes, mocker):
+    def test_limit_parameter(
+            self, dense_encoder_cls, sparse_encoder_cls, input_type, routes, mocker
+        ):
         """Test that the limit parameter works correctly for sync router calls."""
         # Create router with mock encoders
         dense_encoder = MockSymmetricDenseEncoder(name="Dense Encoder")
@@ -683,7 +685,9 @@ class TestHybridRouter:
         assert len(result) > 2  # Should return all matches
 
     @pytest.mark.asyncio
-    async def test_async_limit_parameter(self, routes, mocker):
+    async def test_async_limit_parameter(
+        self, dense_encoder_cls, sparse_encoder_cls, input_type, routes, mocker
+    ):
         """Test that the limit parameter works correctly for async router calls."""
         # Create router with mock encoders
         dense_encoder = MockSymmetricDenseEncoder(name="Dense Encoder")

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -24,7 +24,7 @@ from semantic_router.index.qdrant import QdrantIndex
 from semantic_router.llms import BaseLLM, OpenAILLM
 from semantic_router.route import Route
 from semantic_router.routers import HybridRouter, RouterConfig, SemanticRouter
-from semantic_router.schema import SparseEmbedding
+from semantic_router.schema import RouteChoice, SparseEmbedding
 
 PINECONE_SLEEP = 8
 RETRY_COUNT = 10
@@ -673,7 +673,7 @@ class TestHybridRouter:
         # Test without limit (should return only the top match)
         result = router("test query")
         assert result is not None
-        assert len(result) == 1  # Default behavior returns only the top match
+        assert isinstance(result, RouteChoice)
 
         # Test with limit=2 (should return top 2 matches)
         result = router("test query", limit=2)
@@ -715,7 +715,7 @@ class TestHybridRouter:
         # Test without limit (should return only the top match)
         result = await router.acall("test query")
         assert result is not None
-        assert len(result) == 1  # Default behavior returns only the top match
+        assert isinstance(result, RouteChoice)
 
         # Test with limit=2 (should return top 2 matches)
         result = await router.acall("test query", limit=2)

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -655,6 +655,7 @@ class TestHybridRouter:
             encoder=dense_encoder,
             sparse_encoder=sparse_encoder,
             routes=routes,
+            auto_sync="local",
         )
 
         # Setup a mock for the similarity calculation method
@@ -696,6 +697,7 @@ class TestHybridRouter:
             encoder=dense_encoder,
             sparse_encoder=sparse_encoder,
             routes=routes,
+            auto_sync="local",
         )
 
         # Setup a mock for the async similarity calculation method

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -205,6 +205,15 @@ def routes_4():
         Route(name="Route 2", utterances=["Asparagus"]),
     ]
 
+@pytest.fixture
+def routes_5():
+    return [
+        Route(name="Route 1", utterances=["Hello", "Hi"], metadata={"type": "default"}),
+        Route(name="Route 2", utterances=["Goodbye", "Bye", "Au revoir"]),
+        Route(name="Route 3", utterances=["Hello", "Hi"]),
+        Route(name="Route 4", utterances=["Goodbye", "Bye", "Au revoir"]),
+    ]
+
 
 @pytest.fixture
 def route_single_utterance():
@@ -644,19 +653,35 @@ class TestHybridRouter:
         else:
             assert sparse_call_spy.called
 
+
+@pytest.mark.parametrize(
+    "router_cls",
+    [
+        HybridRouter,
+        SemanticRouter,
+    ],
+)
+class TestRouter:
     def test_limit_parameter(
-            self, dense_encoder_cls, sparse_encoder_cls, input_type, routes, mocker
-        ):
+        self, router_cls, routes_5, mocker
+    ):
         """Test that the limit parameter works correctly for sync router calls."""
         # Create router with mock encoders
         dense_encoder = MockSymmetricDenseEncoder(name="Dense Encoder")
-        sparse_encoder = MockSymmetricSparseEncoder(name="Sparse Encoder")
-        router = HybridRouter(
-            encoder=dense_encoder,
-            sparse_encoder=sparse_encoder,
-            routes=routes,
-            auto_sync="local",
-        )
+        if router_cls == HybridRouter:
+            sparse_encoder = MockSymmetricSparseEncoder(name="Sparse Encoder")
+            router = router_cls(
+                encoder=dense_encoder,
+                sparse_encoder=sparse_encoder,
+                routes=routes_5,
+                auto_sync="local",
+            )
+        else:
+            router = router_cls(
+                encoder=dense_encoder,
+                routes=routes_5,
+                auto_sync="local",
+            )
 
         # Setup a mock for the similarity calculation method
         _ = mocker.patch.object(
@@ -687,18 +712,25 @@ class TestHybridRouter:
 
     @pytest.mark.asyncio
     async def test_async_limit_parameter(
-        self, dense_encoder_cls, sparse_encoder_cls, input_type, routes, mocker
+        self, router_cls, routes_5, mocker
     ):
         """Test that the limit parameter works correctly for async router calls."""
         # Create router with mock encoders
         dense_encoder = MockSymmetricDenseEncoder(name="Dense Encoder")
-        sparse_encoder = MockSymmetricSparseEncoder(name="Sparse Encoder")
-        router = HybridRouter(
-            encoder=dense_encoder,
-            sparse_encoder=sparse_encoder,
-            routes=routes,
-            auto_sync="local",
-        )
+        if router_cls == HybridRouter:
+            sparse_encoder = MockSymmetricSparseEncoder(name="Sparse Encoder")
+            router = router_cls(
+                encoder=dense_encoder,
+                sparse_encoder=sparse_encoder,
+                routes=routes_5,
+                auto_sync="local",
+            )
+        else:
+            router = router_cls(
+                encoder=dense_encoder,
+                routes=routes_5,
+                auto_sync="local",
+            )
 
         # Setup a mock for the async similarity calculation method
         _ = mocker.patch.object(

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -660,12 +660,12 @@ class TestHybridRouter:
         # Setup a mock for the similarity calculation method
         _ = mocker.patch.object(
             router,
-            "_calculate_similarities",
+            "_score_routes",
             return_value=[
-                {"route": "Route 1", "score": 0.9},
-                {"route": "Route 2", "score": 0.8},
-                {"route": "Route 1", "score": 0.7},
-                {"route": "Route 2", "score": 0.6},
+                ("Route 1", 0.9, [0.1, 0.2, 0.3]),
+                ("Route 2", 0.8, [0.4, 0.5, 0.6]),
+                ("Route 3", 0.7, [0.7, 0.8, 0.9]),
+                ("Route 4", 0.6, [1.0, 1.1, 1.2]),
             ],
         )
 
@@ -682,7 +682,7 @@ class TestHybridRouter:
         # Test with limit=None (should return all matches)
         result = router("test query", limit=None)
         assert result is not None
-        assert len(result) > 2  # Should return all matches
+        assert len(result) == 4  # Should return all matches
 
     @pytest.mark.asyncio
     async def test_async_limit_parameter(
@@ -701,12 +701,12 @@ class TestHybridRouter:
         # Setup a mock for the async similarity calculation method
         _ = mocker.patch.object(
             router,
-            "_async_calculate_similarities",
+            "_score_routes",
             return_value=[
-                {"route": "Route 1", "score": 0.9},
-                {"route": "Route 2", "score": 0.8},
-                {"route": "Route 1", "score": 0.7},
-                {"route": "Route 2", "score": 0.6},
+                ("Route 1", 0.9, [0.1, 0.2, 0.3]),
+                ("Route 2", 0.8, [0.4, 0.5, 0.6]),
+                ("Route 3", 0.7, [0.7, 0.8, 0.9]),
+                ("Route 4", 0.6, [1.0, 1.1, 1.2]),
             ],
         )
 
@@ -723,4 +723,4 @@ class TestHybridRouter:
         # Test with limit=None (should return all matches)
         result = await router.acall("test query", limit=None)
         assert result is not None
-        assert len(result) > 2  # Should return all matches
+        assert len(result) == 4  # Should return all matches


### PR DESCRIPTION
This PR will resolve https://github.com/aurelio-labs/semantic-router/issues/586, https://github.com/aurelio-labs/semantic-router/issues/593, and https://github.com/aurelio-labs/semantic-router/issues/589

This pull request enhances the functionality of the `semantic_router` module by introducing asynchronous methods, improving error handling, and adding test coverage for new and existing features. The most significant changes include the addition of an asynchronous `acall` method to the `HybridRouter` class, support for a `limit` parameter in routing methods, and improved test cases to validate these updates.

### Enhancements to Router Functionality:

* **Asynchronous Routing Method**: Added an `acall` method to the `HybridRouter` class, enabling asynchronous routing with support for both dense and sparse vectors. This includes validation for required inputs and integration with the async index query mechanism. (`semantic_router/routers/hybrid.py`, [semantic_router/routers/hybrid.pyR363-R426](diffhunk://#diff-8d989ab449cf069a0832e0c961584e204ecd6af0b1f2b4ae4f82b9cfbb01dffdR363-R426))
* **Support for `limit` Parameter**: Updated the `acall` method in `semantic_router/routers/base.py` to accept a `limit` parameter, allowing users to control the number of route choices returned. The `limit` parameter is also passed to `_async_pass_routes` for further processing. (`semantic_router/routers/base.py`, [[1]](diffhunk://#diff-5469c6c5b738ad6af8b68ff6868e721a3c5577af16c299ece5241354e7e41035R762) [[2]](diffhunk://#diff-5469c6c5b738ad6af8b68ff6868e721a3c5577af16c299ece5241354e7e41035L799-R802)

### Error Handling Improvements:

* **Enhanced Error Messages**: Improved error messages in the `__call__` method of `HybridRouter` to provide more descriptive feedback when required components (e.g., sparse encoder) are not set. (`semantic_router/routers/hybrid.py`, [semantic_router/routers/hybrid.pyL322-R322](diffhunk://#diff-8d989ab449cf069a0832e0c961584e204ecd6af0b1f2b4ae4f82b9cfbb01dffdL322-R322))

### Test Suite Updates:

* **New Test Cases for `limit` Parameter**: Added unit tests to validate the behavior of the `limit` parameter in both synchronous and asynchronous router calls. These tests ensure correct handling of different limit values, including `None` (return all matches). (`tests/unit/test_router.py`, [tests/unit/test_router.pyR656-R840](diffhunk://#diff-68d2964608cb9c8cbb97f888938b8aaf50062b04354365240181151a24608d0bR656-R840))
* **Fixture and Imports**: Introduced a new `routes_5` fixture and updated imports to include `RouteChoice`, ensuring proper setup for the new test cases. (`tests/unit/test_router.py`, [[1]](diffhunk://#diff-68d2964608cb9c8cbb97f888938b8aaf50062b04354365240181151a24608d0bL27-R27) [[2]](diffhunk://#diff-68d2964608cb9c8cbb97f888938b8aaf50062b04354365240181151a24608d0bR209-R218)