### PR TITLE
fix: pinecone.py async initialization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,8 @@ OPENAI_API_KEY=""
 PINECONE_API_KEY=""
 AURELIO_API_KEY=""
 
-POSTGRES_HOST="localhost"  # your host
-POSTGRES_PORT="5432"  # your port
-POSTGRES_DB="routes_db"  # your database name
-POSTGRES_USER="postgres"  # your username
-POSTGRES_PASSWORD="password"  # your password
+POSTGRES_HOST="localhost" # your host
+POSTGRES_PORT="5432" # your port
+POSTGRES_DB="routes_db" # your database name
+POSTGRES_USER="postgres" # your username
+POSTGRES_PASSWORD="password" # your password

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -428,8 +428,10 @@ class PineconeIndex(BaseIndex):
                         region=self.region,
                     )
                     index_ready = "false"
-                    while index_ready != "true" and (
-                        isinstance(index_ready, bool) and not index_ready
+                    while not (
+                        index_ready == "true"
+                        or isinstance(index_ready, bool)
+                        and index_ready
                     ):
                         index_stats = await self._async_describe_index(self.index_name)
                         index_status = index_stats.get("status", {})

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -405,8 +405,16 @@ class PineconeIndex(BaseIndex):
                 index_stats = await self._async_describe_index(self.index_name)
                 # index_stats["status"] can be either a dict or an int (e.g. 404)
                 index_status = index_stats.get("status", {})
-                index_ready = index_status.get("ready", False) if isinstance(index_status, dict) else False
-                if index_ready == "true" or index_ready == True:
+                index_ready = (
+                    index_status.get("ready", False)
+                    if isinstance(index_status, dict)
+                    else False
+                )
+                if (
+                    index_ready == "true"
+                    or isinstance(index_ready, bool)
+                    and index_ready
+                ):
                     # if the index is ready, we return it
                     self.host = index_stats["host"]
                     return index_stats
@@ -420,10 +428,16 @@ class PineconeIndex(BaseIndex):
                         region=self.region,
                     )
                     index_ready = "false"
-                    while index_ready != "true" and index_ready != True:
+                    while index_ready != "true" and (
+                        isinstance(index_ready, bool) and not index_ready
+                    ):
                         index_stats = await self._async_describe_index(self.index_name)
                         index_status = index_stats.get("status", {})
-                        index_ready = index_status.get("ready", False) if isinstance(index_status, dict) else False
+                        index_ready = (
+                            index_status.get("ready", False)
+                            if isinstance(index_status, dict)
+                            else False
+                        )
                         await asyncio.sleep(0.1)
 
                     self.host = index_stats["host"]

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -153,6 +153,7 @@ class PineconeIndex(BaseIndex):
     base_url: Optional[str] = None
     headers: dict[str, str] = {}
     index_host: Optional[str] = "http://localhost:5080"
+    init_async_index: bool = False
 
     def __init__(
         self,
@@ -229,7 +230,8 @@ class PineconeIndex(BaseIndex):
         self.client = self._initialize_client(api_key=self.api_key)
 
         # try initializing index
-        self.index = self._init_index()
+        if not init_async_index:
+            self.index = self._init_index()
 
     def _initialize_client(self, api_key: Optional[str] = None):
         """Initialize the Pinecone client.

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -406,7 +406,6 @@ class PineconeIndex(BaseIndex):
                 index_ready = index_status.get("ready", False) if isinstance(index_status, dict) else False
                 if index_ready == "true" or index_ready == True:
                     # if the index is ready, we return it
-                    self.index = index_stats
                     self.host = index_stats["host"]
                     return index_stats
                 else:
@@ -425,13 +424,11 @@ class PineconeIndex(BaseIndex):
                         index_ready = index_status.get("ready", False) if isinstance(index_status, dict) else False
                         await asyncio.sleep(0.1)
 
-                    self.index = index_stats
                     self.host = index_stats["host"]
                     return index_stats
             else:
                 # if the index exists, we return it
                 index_stats = await self._async_describe_index(self.index_name)
-                self.index = index_stats
                 self.host = index_stats["host"]
                 return index_stats
         self.host = index_stats["host"] if index_stats else ""
@@ -518,9 +515,6 @@ class PineconeIndex(BaseIndex):
         :param sparse_embeddings: List of sparse embeddings to upsert.
         :type sparse_embeddings: Optional[List[SparseEmbedding]]
         """
-        if self.index is None:
-            self.dimensions = self.dimensions or len(embeddings[0])
-            self.index = await self._init_async_index(force_create=True)
         vectors_to_upsert = build_records(
             embeddings=embeddings,
             routes=routes,
@@ -928,8 +922,6 @@ class PineconeIndex(BaseIndex):
         :type config: ConfigParameter
         """
         config.scope = config.scope or self.namespace
-        if self.index is None:
-            raise ValueError("Index has not been initialized.")
         if self.dimensions is None:
             raise ValueError("Must set PineconeIndex.dimensions before writing config.")
         pinecone_config = config.to_pinecone(dimensions=self.dimensions)
@@ -1230,8 +1222,6 @@ class PineconeIndex(BaseIndex):
         :return: A tuple containing a list of vector IDs and a list of metadata dictionaries.
         :rtype: tuple[list[str], list[dict]]
         """
-        if self.index is None:
-            raise ValueError("Index is None, could not retrieve vector IDs.")
         if self.host == "":
             raise ValueError("self.host is not initialized.")
 

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -1000,6 +1000,11 @@ class PineconeIndex(BaseIndex):
         self.index = None
 
     # __ASYNC CLIENT METHODS__
+    async def adelete_index(self):
+        """Asynchronously delete the index."""
+        await asyncio.to_thread(self.client.delete_index, self.index_name)
+        self.index = None
+
     async def _async_query(
         self,
         vector: list[float],

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -1023,8 +1023,19 @@ class PineconeIndex(BaseIndex):
     # __ASYNC CLIENT METHODS__
     async def adelete_index(self):
         """Asynchronously delete the index."""
-        await asyncio.to_thread(self.client.delete_index, self.index_name)
+        if not self.base_url:
+            raise ValueError("base_url is not set for PineconeIndex.")
+
+        async with aiohttp.ClientSession() as session:
+            async with session.delete(
+                f"{self.base_url}/indexes/{self.index_name}",
+                headers=self.headers,
+            ) as response:
+                res = await response.json(content_type=None)
+                if response.status != 202:
+                    raise Exception(f"Failed to delete index: {response.status}", res)
         self.index = None
+        return res
 
     async def _async_query(
         self,

--- a/semantic_router/routers/base.py
+++ b/semantic_router/routers/base.py
@@ -785,7 +785,13 @@ class BaseRouter(BaseModel):
         :return: The route choice.
         :rtype: RouteChoice
         """
-        if not self.index.is_ready():
+        if not (
+            self.index.is_ready()
+            or (
+                isinstance(self.index, PineconeIndex)
+                and self.index._is_async_ready()
+            )
+        ):
             # TODO: need async version for qdrant
             raise ValueError("Index is not ready.")
         # if no vector provided, encode text to get vector

--- a/semantic_router/routers/base.py
+++ b/semantic_router/routers/base.py
@@ -814,10 +814,7 @@ class BaseRouter(BaseModel):
         """
         if not (
             self.index.is_ready()
-            or (
-                isinstance(self.index, PineconeIndex)
-                and self.index._is_async_ready()
-            )
+            or (isinstance(self.index, PineconeIndex) and self.index._is_async_ready())
         ):
             # TODO: need async version for qdrant
             raise ValueError("Index is not ready.")

--- a/semantic_router/routers/base.py
+++ b/semantic_router/routers/base.py
@@ -360,6 +360,7 @@ class BaseRouter(BaseModel):
     aggregation: str = "mean"
     aggregation_method: Optional[Callable] = None
     auto_sync: Optional[str] = None
+    async_init_index: bool = False
 
     model_config: ClassVar[ConfigDict] = ConfigDict(arbitrary_types_allowed=True)
 
@@ -373,6 +374,7 @@ class BaseRouter(BaseModel):
         top_k: int = 5,
         aggregation: str = "mean",
         auto_sync: Optional[str] = None,
+        async_init_index: bool = False,
     ):
         """Initialize a BaseRouter object. Expected to be used as a base class only,
         not directly instantiated.
@@ -434,7 +436,8 @@ class BaseRouter(BaseModel):
             if route.score_threshold is None:
                 route.score_threshold = self.score_threshold
         # initialize index
-        self._init_index_state()
+        if not async_init_index:
+            self._init_index_state()
 
     def _get_index(self, index: Optional[BaseIndex]) -> BaseIndex:
         """Get the index to use.
@@ -507,6 +510,30 @@ class BaseRouter(BaseModel):
             )
             sync_strategy = diff.get_sync_strategy(self.auto_sync)
             self._execute_sync_strategy(sync_strategy)
+
+    async def _async_init_index_state(self):
+        """Asynchronously initializes an index (where required) and runs auto_sync if active."""
+        # initialize index now, check if we need dimensions
+        if self.index.dimensions is None:
+            dims = len(self.encoder(["test"])[0])
+            self.index.dimensions = dims
+        # now init index
+        if isinstance(self.index, PineconeIndex):
+            await self.index._init_async_index(force_create=True)
+        # TODO: convert the following to async where applicable.
+        elif isinstance(self.index, PostgresIndex):
+            self._init_index_state()
+
+        # run auto sync if active
+        if self.auto_sync:
+            local_utterances = self.to_config().to_utterances()
+            remote_utterances = await self.index.aget_utterances(include_metadata=True)
+            diff = UtteranceDiff.from_utterances(
+                local_utterances=local_utterances,
+                remote_utterances=remote_utterances,
+            )
+            sync_strategy = diff.get_sync_strategy(self.auto_sync)
+            await self._async_execute_sync_strategy(sync_strategy)
 
     def _set_score_threshold(self):
         """Set the score threshold for the layer based on the encoder

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -241,6 +241,8 @@ def get_test_indexes():
 
 def get_test_async_indexes():
     indexes = [LocalIndex]
+    if importlib.util.find_spec("pinecone") is not None:
+        indexes.append(PineconeIndex)
     return indexes
 
 


### PR DESCRIPTION
Running `PineconeIndex`'s `_init_async_index` was not working for me for the following reasons:
1. API returning boolean, but code checking for string literal `"true"`
2. `self.index` stays `None`, short-circuiting all the async operations.
3. `self.host` is not being set, deviating from the synchronous method counterpart.

To address these, this PR includes:
- Set `self.index` to prevent short circuit on async calls when `self.index` is `None`.
- Make sure to always set `self.host` to match the behavior of the synchronous initialization method.
- Always return `index_stats` if index exists or was created (previously `None` was returned for an existing index).