### PR TITLE
feat: added adelete_index function

### DIFF
--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -1011,7 +1011,7 @@ class PineconeIndex(BaseIndex):
                 headers=self.headers,
             ) as response:
                 res = await response.json(content_type=None)
-                if response.status != 200:
+                if response.status != 202:
                     raise Exception(f"Failed to delete index: {response.status}", res)
         self.index = None
         return res

--- a/semantic_router/index/pinecone.py
+++ b/semantic_router/index/pinecone.py
@@ -1002,8 +1002,19 @@ class PineconeIndex(BaseIndex):
     # __ASYNC CLIENT METHODS__
     async def adelete_index(self):
         """Asynchronously delete the index."""
-        await asyncio.to_thread(self.client.delete_index, self.index_name)
+        if not self.base_url:
+            raise ValueError("base_url is not set for PineconeIndex.")
+
+        async with aiohttp.ClientSession() as session:
+            async with session.delete(
+                f"{self.base_url}/indexes/{self.index_name}",
+                headers=self.headers,
+            ) as response:
+                res = await response.json(content_type=None)
+                if response.status != 200:
+                    raise Exception(f"Failed to delete index: {response.status}", res)
         self.index = None
+        return res
 
     async def _async_query(
         self,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Use aiohttp for async index deletion

- Validate `base_url` before deletion

- Raise exception on non-200 status

- Return deletion response JSON


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pinecone.py</strong><dd><code>Implement asynchronous HTTP delete for PineconeIndex</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

semantic_router/index/pinecone.py

<li>Replace <code>asyncio.to_thread</code> with HTTP delete call<br> <li> Use <code>aiohttp</code> to delete index asynchronously<br> <li> Add <code>base_url</code> validation and error handling<br> <li> Return parsed response JSON on success


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/609/files#diff-c57f54339773ad317ee6eafd071395202933f9eeaf59a10c28fc22d06bf564a2">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>