### PR TITLE
feat: optimize sync test

### DIFF
--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -22,68 +22,6 @@ from semantic_router.routers import HybridRouter, SemanticRouter
 from semantic_router.schema import Utterance
 from semantic_router.utils.logger import logger
 
-RETRY_COUNT = 5
-
-
-# retry decorator for PineconeIndex cases - which need delay
-def retry(max_retries: int = 5, delay: int = 8):
-    """Retry decorator, currently used for PineconeIndex which often needs some time
-    to be populated and have all correct data. Once full Pinecone mock is built we
-    should remove this decorator.
-
-    :param max_retries: Maximum number of retries.
-    :param delay: Delay between retries in seconds.
-    """
-
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            count = 0
-            last_exception = None
-            while count < max_retries:
-                try:
-                    return func(*args, **kwargs)
-                except Exception as e:
-                    logger.warning(f"Attempt {count} | Error in {func.__name__}: {e}")
-                    last_exception = e
-                    count += 1
-                    time.sleep(delay)
-            raise last_exception
-
-        return wrapper
-
-    return decorator
-
-
-# retry decorator for PineconeIndex cases (which need delay)
-def async_retry(max_retries: int = 5, delay: int = 8):
-    """Retry decorator, currently used for PineconeIndex which often needs some time
-    to be populated and have all correct data. Once full Pinecone mock is built we
-    should remove this decorator.
-
-    :param max_retries: Maximum number of retries.
-    :param delay: Delay between retries in seconds.
-    """
-
-    def decorator(func):
-        @wraps(func)
-        async def wrapper(*args, **kwargs):
-            count = 0
-            last_exception = None
-            while count < max_retries:
-                try:
-                    return await func(*args, **kwargs)
-                except Exception as e:
-                    logger.warning(f"Attempt {count} | Error in {func.__name__}: {e}")
-                    last_exception = e
-                    count += 1
-                    await asyncio.sleep(delay)
-            raise last_exception
-
-        return wrapper
-
-    return decorator
-
 
 def mock_encoder_call(utterances):
     # Define a mapping of utterances to return values

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -1,9 +1,6 @@
-import asyncio
 import importlib
 import os
-import time
 from datetime import datetime
-from functools import wraps
 from platform import python_version
 from typing import Optional
 
@@ -20,7 +17,6 @@ from semantic_router.index import (
 from semantic_router.route import Route
 from semantic_router.routers import HybridRouter, SemanticRouter
 from semantic_router.schema import Utterance
-from semantic_router.utils.logger import logger
 
 
 def mock_encoder_call(utterances):
@@ -65,7 +61,7 @@ def init_index(
             dimensions=dimensions,
             namespace=namespace,
             init_async_index=init_async_index,
-            base_url="http://localhost:5080"
+            base_url="http://localhost:5080",
         )
     else:
         index = index_cls()
@@ -404,9 +400,7 @@ class TestSemanticRouter:
             # confirm local and remote are synced
             assert route_layer.is_synced()
             # now confirm utterances are correct
-            local_utterances = route_layer.index.get_utterances(
-                include_metadata=False
-            )
+            local_utterances = route_layer.index.get_utterances(include_metadata=False)
             # we sort to ensure order is the same
             # TODO JB: there is a bug here where if we include_metadata=True it fails
             local_utterances.sort(key=lambda x: x.to_str(include_metadata=False))
@@ -451,9 +445,7 @@ class TestSemanticRouter:
                 Utterance(route="Route 2", utterance="Goodbye"),
                 Utterance(route="Route 3", utterance="Boo"),
             ]
-            local_utterances = route_layer.index.get_utterances(
-                include_metadata=True
-            )
+            local_utterances = route_layer.index.get_utterances(include_metadata=True)
             # we sort to ensure order is the same
             local_utterances.sort(key=lambda x: x.to_str(include_metadata=True))
             assert local_utterances == r1_utterances
@@ -467,9 +459,7 @@ class TestSemanticRouter:
 
             # confirm local and remote are synced
             assert route_layer.is_synced()
-            local_utterances = route_layer.index.get_utterances(
-                include_metadata=True
-            )
+            local_utterances = route_layer.index.get_utterances(include_metadata=True)
             # we sort to ensure order is the same
             local_utterances.sort(key=lambda x: x.to_str(include_metadata=True))
             assert local_utterances == [
@@ -524,9 +514,7 @@ class TestSemanticRouter:
             # confirm local and remote are synced
             assert route_layer.is_synced()
             # now confirm utterances are correct
-            local_utterances = route_layer.index.get_utterances(
-                include_metadata=True
-            )
+            local_utterances = route_layer.index.get_utterances(include_metadata=True)
             # we sort to ensure order is the same
             local_utterances.sort(key=lambda x: x.to_str(include_metadata=True))
             assert local_utterances == [
@@ -595,6 +583,7 @@ class TestSemanticRouter:
         # clear index if pinecone
         if index_cls is PineconeIndex:
             route_layer.index.client.delete_index(route_layer.index.index_name)
+
 
 @pytest.mark.parametrize(
     "index_cls,router_cls",
@@ -696,13 +685,10 @@ class TestAsyncSemanticRouter:
                 index=pinecone_index,
                 auto_sync="local",
             )
-            assert await route_layer.index.aget_utterances(
-                include_metadata=True
-            ) == [
+            assert await route_layer.index.aget_utterances(include_metadata=True) == [
                 Utterance(route="Route 1", utterance="Hello"),
                 Utterance(route="Route 2", utterance="Hi"),
             ], "The routes in the index should match the local routes"
-
 
     @pytest.mark.skipif(
         os.environ.get("PINECONE_API_KEY") is None, reason="Pinecone API key required"
@@ -728,9 +714,7 @@ class TestAsyncSemanticRouter:
                 index=pinecone_index,
                 auto_sync="remote",
             )
-            assert await route_layer.index.aget_utterances(
-                include_metadata=True
-            ) == [
+            assert await route_layer.index.aget_utterances(include_metadata=True) == [
                 Utterance(route="Route 1", utterance="Hello"),
                 Utterance(route="Route 2", utterance="Hi"),
             ], "The routes in the index should match the local routes"


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Remove retry decorators and related sleep calls

- Simplify tests with direct assertions

- Add `base_url` to PineconeIndex in init_index

- Clean up unused `PINECONE_SLEEP` and `RETRY_COUNT`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_sync.py</strong><dd><code>Simplify sync tests and init_index</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_sync.py

<li>Removed <code>retry</code> and <code>async_retry</code> decorators and constants<br> <li> Deleted <code>time.sleep</code> and <code>asyncio.sleep</code> calls<br> <li> Simplified test logic with direct assertions<br> <li> Added <code>base_url="http://localhost:5080"</code> in <code>init_index</code>


</details>


  </td>
  <td><a href="https://github.com/aurelio-labs/semantic-router/pull/621/files#diff-4f00405732d882f0c91cc43f779703ae044cf1517b25d6d591b59cf59d0054f7">+208/-402</a></td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>