### PR TITLE
fix: Add UTF-8 encoding support for JSON file reading

### DIFF
--- a/semantic_router/routers/base.py
+++ b/semantic_router/routers/base.py
@@ -114,7 +114,7 @@ class RouterConfig:
         """
         logger.info(f"Loading route config from {path}")
         _, ext = os.path.splitext(path)
-        with open(path, "r") as f:
+        with open(path, "r", encoding="utf-8") as f:
             if ext == ".json":
                 layer = json.load(f)
             elif ext in [".yaml", ".yml"]:

--- a/semantic_router/tokenizers.py
+++ b/semantic_router/tokenizers.py
@@ -59,7 +59,7 @@ class BaseTokenizer:
         if isinstance(path, str):
             path = Path(path)
 
-        with open(path) as fp:
+        with open(path, encoding="utf-8") as fp:
             config = json.load(fp)
         return cls(**config)
 


### PR DESCRIPTION
## Problem
The code didn't specify encoding when reading JSON files, which could cause failures when reading JSON files containing non-ASCII characters (e.g., Chinese characters).

## Changes
- Added `encoding="utf-8"` parameter to `RouterConfig.from_file()` in `semantic_router/routers/base.py`
- Added `encoding="utf-8"` parameter to `from_file()` in `semantic_router/tokenizers.py`

## Impact
- Ensures all JSON file reading operations use UTF-8 encoding
- Supports JSON configuration files containing non-ASCII characters (e.g., Chinese)
- Backward compatible, no breaking changes