### PR TITLE
fix: markers on a fixture have no effect at all

### DIFF
--- a/tests/functional/encoders/test_bm25_functional.py
+++ b/tests/functional/encoders/test_bm25_functional.py
@@ -19,16 +19,16 @@ QUERIES = ["weights", "ratio logarithm"]
 
 
 @pytest.fixture
-@pytest.mark.skipif(
-    os.environ.get("RUN_HF_TESTS") is None,
-    reason="Set RUN_HF_TESTS=1 to run. This test downloads models from Hugging Face which can time out in CI.",
-)
 def bm25_encoder():
     sparse_encoder = BM25Encoder(use_default_params=True)
     sparse_encoder.fit([Route(name="test_route", utterances=UTTERANCES)])
     return sparse_encoder
 
 
+@pytest.mark.skipif(
+    os.environ.get("RUN_HF_TESTS") is None,
+    reason="Set RUN_HF_TESTS=1 to run. This test downloads models from Hugging Face which can time out in CI.",
+)
 class TestBM25Encoder:
     def _sparse_to_vector(self, sparse_embedding, vocab_size):
         """Re-constructs the full (sparse_embedding.shape[0], vocab_size) array"""
@@ -37,10 +37,6 @@ class TestBM25Encoder:
             * np.atleast_2d(sparse_embedding[:, 1]).T
         ).sum(axis=0)
 
-    @pytest.mark.skipif(
-        os.environ.get("RUN_HF_TESTS") is None,
-        reason="Set RUN_HF_TESTS=1 to run. This test downloads models from Hugging Face which can time out in CI.",
-    )
     def test_bm25_scoring(self, bm25_encoder):
         vocab_size = bm25_encoder._tokenizer.vocab_size
         expected = np.array(

--- a/tests/unit/encoders/test_bm25.py
+++ b/tests/unit/encoders/test_bm25.py
@@ -16,10 +16,6 @@ UTTERANCES = [
 
 
 @pytest.fixture
-@pytest.mark.skipif(
-    os.environ.get("RUN_HF_TESTS") is None,
-    reason="Set RUN_HF_TESTS=1 to run. This test downloads models from Hugging Face which can time out in CI.",
-)
 def bm25_encoder():
     sparse_encoder = BM25Encoder(use_default_params=True)
     sparse_encoder.fit(
@@ -45,6 +41,10 @@ def routes():
     ]
 
 
+@pytest.mark.skipif(
+    os.environ.get("RUN_HF_TESTS") is None,
+    reason="Set RUN_HF_TESTS=1 to run. This test downloads models from Hugging Face which can time out in CI.",
+)
 class TestBM25Encoder:
     def test_initialization(self, bm25_encoder):
         assert bm25_encoder._tokenizer is not None
@@ -97,10 +97,6 @@ class TestBM25Encoder:
         with pytest.raises(ValueError, match="No documents provided for encoding"):
             bm25_encoder.encode_queries([])
 
-    @pytest.mark.skipif(
-        os.environ.get("RUN_HF_TESTS") is None,
-        reason="Set RUN_HF_TESTS=1 to run. This test downloads models from Hugging Face which can time out in CI.",
-    )
     def test_encode_queries_unfitted(self):
         encoder = BM25Encoder(use_default_params=True)
         with pytest.raises(ValueError, match="Encoder not fitted"):
@@ -117,10 +113,6 @@ class TestBM25Encoder:
         with pytest.raises(ValueError, match="No documents provided for encoding"):
             bm25_encoder.encode_documents([])
 
-    @pytest.mark.skipif(
-        os.environ.get("RUN_HF_TESTS") is None,
-        reason="Set RUN_HF_TESTS=1 to run. This test downloads models from Hugging Face which can time out in CI.",
-    )
     def test_encode_documents_unfitted(self):
         encoder = BM25Encoder(use_default_params=True)
         with pytest.raises(ValueError, match="Encoder not fitted"):


### PR DESCRIPTION
This will become an error with pytest 9.0.0: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function