### PR TITLE
fix: correct aggregation error message case and aget_routes signature

### DIFF
--- a/semantic_router/index/local.py
+++ b/semantic_router/index/local.py
@@ -241,13 +241,13 @@ class LocalIndex(BaseIndex):
             route_names = [self.routes[i] for i in idx]
         return scores, route_names
 
-    def aget_routes(self):
+    async def aget_routes(self):
         """Get all routes from the index.
 
         :return: A list of routes.
         :rtype: List[str]
         """
-        logger.error("Sync remove is not implemented for LocalIndex.")
+        logger.error("Async get routes is not implemented for LocalIndex.")
 
     def _write_config(self, config: ConfigParameter):
         """Write the config to the index.

--- a/semantic_router/routers/base.py
+++ b/semantic_router/routers/base.py
@@ -421,7 +421,7 @@ class BaseRouter(BaseModel):
         self.aggregation = aggregation
         if self.aggregation not in ["sum", "mean", "max"]:
             raise ValueError(
-                f"Unsupported aggregation method chosen: {aggregation}. Choose either 'SUM', 'MEAN', or 'MAX'."
+                f"Unsupported aggregation method chosen: {aggregation}. Choose either 'sum', 'mean', or 'max'."
             )
         self.aggregation_method = self._set_aggregation_method(self.aggregation)
         # to keep PostgresIndex backwards compatible we will default auto_sync to "local",
@@ -1295,19 +1295,6 @@ class BaseRouter(BaseModel):
         Not yet implemented for BaseRouter.
         """
         raise NotImplementedError("This method has not yet been implemented.")
-        route_mapping = {route.name: route for route in self.routes}
-        index_routes = self.index.get_utterances()
-        new_routes_names = []
-        new_routes = []
-        for route_name, utterance in index_routes:
-            if route_name in route_mapping:
-                if route_name not in new_routes_names:
-                    existing_route = route_mapping[route_name]
-                    new_routes.append(existing_route)
-
-                new_routes.append(Route(name=route_name, utterances=[utterance]))
-            route = route_mapping[route_name]
-            self.routes.append(route)
 
     def _get_hash(self) -> ConfigParameter:
         """Get the hash of the current routes.
@@ -1530,7 +1517,7 @@ class BaseRouter(BaseModel):
             return lambda x: max(x)
         else:
             raise ValueError(
-                f"Unsupported aggregation method chosen: {aggregation}. Choose either 'SUM', 'MEAN', or 'MAX'."
+                f"Unsupported aggregation method chosen: {aggregation}. Choose either 'sum', 'mean', or 'max'."
             )
 
     def _score_routes(


### PR DESCRIPTION
## Changes

### 1. Aggregation error message uses wrong case (`routers/base.py`)

The validation checks against lowercase values but the error message told users to use uppercase:

```python
if self.aggregation not in ["sum", "mean", "max"]:  # checks lowercase
    raise ValueError(
        f"... Choose either 'SUM', 'MEAN', or 'MAX'."  # ← uppercase
    )
```

Following the error message causes the same error to trigger again. Fixed by aligning the message to lowercase. Applied to both occurrences (lines 424 and 1533 before this change).

### 2. `aget_routes` in `LocalIndex` declared as sync (`index/local.py`)

`aget_routes` follows the `a`-prefix async convention used throughout the codebase (e.g. `aadd`, `adelete`, `asearch`) but was declared as a sync `def`. The error message also said "Sync remove is not implemented" — wrong method name and wrong type.

Fixed: `async def aget_routes` with correct error message.

### 3. Dead code after `raise NotImplementedError` in `_refresh_routes`

13 lines of unreachable code (incomplete draft implementation) were left after the `raise NotImplementedError`. Removed.