### PR TITLE
fix: top_scores must return results sorted by score

### DIFF
--- a/semantic_router/linear.py
+++ b/semantic_router/linear.py
@@ -30,5 +30,10 @@ def top_scores(sim: np.ndarray, top_k: int = 5) -> Tuple[np.ndarray, np.ndarray]
     top_k = min(top_k, sim.shape[0])
     idx = np.argpartition(sim, -top_k)[-top_k:]
     scores = sim[idx]
+    # np.argpartition only guarantees the correct top-k set, not their order,
+    # so sort the selected results ascending by score before returning.
+    order = np.argsort(scores)
+    scores = scores[order]
+    idx = idx[order]
 
     return scores, idx

--- a/tests/functional/test_linear.py
+++ b/tests/functional/test_linear.py
@@ -67,3 +67,12 @@ def test_top_scores__scores(test_index):
 
     # Scores and indexes should be sorted ascending
     assert np.allclose(scores, np.array([0.0, 0.89442719, 1.0]))
+
+
+def test_top_scores_returns_sorted_ascending():
+    # argpartition selects the top-k set but not in order; a general (>3 element)
+    # input must still come out sorted ascending by score.
+    sim = np.array([0.1, 0.9, 0.5, 0.3, 0.7])  # top-3: 0.5(i2), 0.7(i4), 0.9(i1)
+    scores, idx = top_scores(sim, top_k=3)
+    assert np.allclose(scores, np.array([0.5, 0.7, 0.9])), f"scores={scores}"
+    assert np.array_equal(idx, np.array([2, 4, 1])), f"idx={idx}"


### PR DESCRIPTION
### What's broken

`top_scores` selects the top-k with `np.argpartition`, which guarantees the correct top-k **set** but **not their order**:

```python
idx = np.argpartition(sim, -top_k)[-top_k:]
scores = sim[idx]
return scores, idx
```

So for general inputs the output is unsorted:

```python
top_scores(np.array([0.1, 0.9, 0.5, 0.3, 0.7]), top_k=3)
# scores = [0.5 0.9 0.7]   -- expected sorted [0.5 0.7 0.9]
```

The repo's own tests document a **sorted** contract — `test_top_scores__is_sorted` ("returns a sorted list of scores", asserts `idx == [2, 1, 0]`) and the order-sensitive `test_top_scores__scores` — but they pass only *by luck*: their 3-element inputs happen to come out ordered. `top_scores` is a public function used by `LocalIndex.query` / `HybridLocalIndex.query`, whose callers reasonably expect ordered results (e.g. `scores[-1]` = best match).

### Fix

Sort the selected top-k ascending by score before returning (ascending matches the existing passing tests).

### Tests

Adds `test_top_scores_returns_sorted_ascending` with a 5-element input where the bug is visible. Full `tests/functional/test_linear.py` passes (6), including the existing order-sensitive cases.