### PR TITLE
fix: correct OllamaEncoder _initialize_client docstring

### DIFF
--- a/semantic_router/encoders/ollama.py
+++ b/semantic_router/encoders/ollama.py
@@ -57,11 +57,11 @@ class OllamaEncoder(DenseEncoder):
         self.client = self._initialize_client(base_url=base_url)
 
     def _initialize_client(self, base_url: str):
-        """Initializes the Google AI Platform client.
+        """Initializes the Ollama embedding client.
 
         :param base_url: hosted URL of ollama.
-        :return: An instance of the TextEmbeddingModel client.
-        :rtype: TextEmbeddingModel
+        :return: An instance of the Ollama client.
+        :rtype: ollama.Client
         :raise ImportError: If the required ollama library is not installed.
         :raise ValueError: If the hosted base url is not provided properly or if the ollama
             client fails to initialize.


### PR DESCRIPTION
Fixed incorrect docstring in OllamaEncoder._initialize_client method.

- Changed: "Initializes the Google AI Platform client" → "Initializes the Ollama embedding client"
- Updated return type documentation to reflect actual Ollama client
- Fixes documentation inconsistency (issue #634 pattern)

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>