### PR TITLE
docs: rewrite guides for clarity; fix stale API references

### DIFF
--- a/docs/get-started/introduction.md
+++ b/docs/get-started/introduction.md
@@ -1,41 +1,35 @@
-Semantic Router is a superfast decision-making layer for LLMs and agents. Instead of waiting for slow LLM generations to make tool-use decisions, it uses semantic vector space to route requests based on meaning.
+Semantic Router is a superfast decision layer for LLMs and agents. Most tools make routing decisions by asking an LLM and waiting for it to answer. That's slow. Semantic Router skips the wait — it compares the *meaning* of an input against your routes in vector space and picks a match in milliseconds.
 
-## What is Semantic Router?
+The payoff is simple. Decisions land in milliseconds, not seconds. You skip an LLM call, so you cut cost. And because routes are explicit, you stay in control of what happens next.
 
-Semantic Router enables:
+## How it works
 
-- **Faster decisions**: Make routing decisions in milliseconds rather than seconds
-- **Lower costs**: Avoid expensive LLM inference for simple routing tasks
-- **Better control**: Direct conversations, queries, and agent actions with precision
-- **Full flexibility**: Use cloud APIs or run everything locally
+You define routes, each one a handful of example phrases. Semantic Router embeds those examples once, up front. At runtime it embeds the incoming request and matches it to the closest route by meaning. No keyword matching, and no LLM in the hot path.
 
-## Key Features
+From there you can:
 
-- **Simple API**: Set up routes with just a few lines of code
-- **Dynamic routes**: Generate parameters and trigger function calls
-- **Multiple integrations**: Works with Cohere, OpenAI, Hugging Face, FastEmbed, and more
-- **Vector store support**: Integrates with Pinecone and Qdrant for persistence
-- **Multi-modal capabilities**: Route based on image content, not just text
-- **Local execution**: Run entirely on your machine with no API dependencies
+- **Trigger functions.** Dynamic routes extract parameters and call your code.
+- **Go multi-modal.** Route on images, not just text.
+- **Scale it.** Persist routes in Pinecone, Qdrant, or Postgres.
+- **Run it anywhere.** Cloud APIs, fully local, or a mix of both.
 
-## Version 0.1 Released
+It works with the encoders you already use — OpenAI, Cohere, Hugging Face, FastEmbed, and more.
 
-Semantic Router v0.1 is now available! If you're migrating from an earlier version, please see our [migration guide](../user-guide/guides/migration-to-v1).
+## Running local or in the cloud
 
-## Getting Started
+You choose how much runs on your machine:
 
-For a quick introduction to using Semantic Router, check out our [quickstart guide](quickstart).
+- **Cloud.** Embeddings from OpenAI, Cohere, or another API.
+- **Hybrid.** Local embeddings, API-based LLMs.
+- **Fully local.** Everything on your hardware, with models like Llama and Mistral. No external calls.
 
-## Execution Options
+## Start here
 
-Semantic Router supports multiple execution modes:
+New to Semantic Router? The [quickstart](quickstart) gets you routing in a few minutes.
 
-- **Cloud-based**: Using OpenAI, Cohere, or other API-based embeddings
-- **Hybrid**: Combining local embeddings with API-based LLMs
-- **Fully local**: Run everything on your machine with models like Llama and Mistral
+Upgrading from a 0.0.x release? v0.1 introduced breaking changes — the [migration guide](../user-guide/guides/migration-to-v1) walks you through them.
 
 ## Resources
 
-- [Documentation](https://docs.aurelio.ai/semantic-router/index.html)
-- [GitHub Repository](https://github.com/aurelio-labs/semantic-router)
-- [Online Course](https://www.aurelio.ai/course/semantic-router) 
+- [GitHub repository](https://github.com/aurelio-labs/semantic-router)
+- [Online course](https://www.aurelio.ai/course/semantic-router)

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -1,24 +1,27 @@
-*Semantic-router* is a lightweight library that helps you intelligently route text to the right handlers based on meaning rather than exact keyword matching. It's perfect for building chatbots, classification systems, or any application that needs to understand user intent.
+Semantic Router sends text to the right handler based on *meaning*, not keywords. That makes it a good fit for chatbots, intent classification, guardrails — anything that needs to understand what a user is actually asking.
 
-To get started with *semantic-router* we install it like so:
+Install it:
 
 ```bash
 pip install -qU semantic-router
 ```
 
-> **Warning**
-> If wanting to use a fully local version of semantic router you can use `HuggingFaceEncoder` and `LlamaCppLLM` (`pip install -qU "semantic-router[local]"`, see [here](../user-guide/guides/local-execution)). To use the `HybridRouteLayer` you must `pip install -qU "semantic-router[hybrid]"`.
+Want everything to run locally, with no API calls? Install the `local` extra and use `HuggingFaceEncoder` with `LlamaCppLLM`. The [local execution guide](../user-guide/guides/local-execution) walks through it.
 
-## Defining Routes
+```bash
+pip install -qU "semantic-router[local]"
+```
 
-We begin by defining a set of `Route` objects. A Route represents a specific topic or intent that you want to detect in user input. Each Route is defined by example utterances that serve as a semantic reference point.
+## Define your routes
 
-Let's try two simple routes for now — one for talk on *politics* and another for *chitchat*:
+A `Route` is a topic or intent you want to detect. You describe it with example utterances — a few phrases a user might say. Those examples become the route's semantic reference point.
+
+Let's start with two: one for *politics*, one for *chitchat*.
 
 ```python
 from semantic_router import Route
 
-# we could use this as a guide for our chatbot to avoid political conversations
+# use this to steer a chatbot away from political conversation
 politics = Route(
     name="politics",
     utterances=[
@@ -30,8 +33,7 @@ politics = Route(
     ],
 )
 
-# this could be used as an indicator to our chatbot to switch to a more
-# conversational prompt
+# and this to switch the chatbot into a more conversational mode
 chitchat = Route(
     name="chitchat",
     utterances=[
@@ -43,75 +45,72 @@ chitchat = Route(
     ],
 )
 
-# we place both of our decisions together into single list
 routes = [politics, chitchat]
 ```
 
-## Setting Up an Encoder
+## Pick an encoder
 
-With our routes ready, now we initialize an embedding / encoder model. The encoder converts text into numerical vectors, allowing the system to measure semantic similarity. We currently support `CohereEncoder` and `OpenAIEncoder` — more encoders will be added soon.
+An encoder turns text into a vector, so we can measure how similar two pieces of text are. Semantic Router supports a lot of them — OpenAI, Cohere, Hugging Face, FastEmbed, and more. The [encoders guide](../user-guide/components/encoders) has the full list.
 
-To initialize them:
+We'll use Cohere or OpenAI here:
 
 ```python
 import os
 from semantic_router.encoders import CohereEncoder, OpenAIEncoder
 
-# for Cohere
+# Cohere
 os.environ["COHERE_API_KEY"] = "<YOUR_API_KEY>"
 encoder = CohereEncoder()
 
-# or for OpenAI
+# or OpenAI
 os.environ["OPENAI_API_KEY"] = "<YOUR_API_KEY>"
 encoder = OpenAIEncoder()
 ```
 
-## Creating a RouteLayer
+## Create the router
 
-With our `routes` and `encoder` defined we now create a `SemanticRouter`. The SemanticRouter is the decision-making engine that compares incoming text against your routes to find the best semantic match.
+The `SemanticRouter` is the decision engine. Hand it your encoder and routes:
 
 ```python
-from semantic_router.routers import SemanticRouter
+from semantic_router import SemanticRouter
 
-rl = SemanticRouter(encoder=encoder, routes=routes)
+sr = SemanticRouter(encoder=encoder, routes=routes)
 ```
 
-## Making Routing Decisions
+## Route a query
 
-We can now use our route layer to make super fast routing decisions based on user queries. Behind the scenes, the system converts both your example utterances and the incoming query into vectors and finds the closest match.
-
-Let's try with two queries that should trigger our route decisions:
+Now call it. Under the hood, the router embeds your query and finds the closest route.
 
 ```python
-rl("don't you love politics?").name
+sr("don't you love politics?").name
 ```
 
 ```
 [Out]: 'politics'
 ```
 
-Correct decision, let's try another:
+Right answer. One more:
 
 ```python
-rl("how's the weather today?").name
+sr("how's the weather today?").name
 ```
 
 ```
 [Out]: 'chitchat'
 ```
 
-We get both decisions correct! The power of semantic routing is that it works even when queries don't exactly match your examples but are similar in meaning.
+Both correct. Notice the queries don't match any utterance word for word — they just mean the same thing. That's the whole point.
 
-## Handling Unmatched Queries
+## When nothing matches
 
-Now let's try sending an unrelated query:
+Send something unrelated:
 
 ```python
-rl("I'm interested in learning about llama 2").name
+sr("I'm interested in learning about llama 2").name
 ```
 
 ```
 [Out]:
 ```
 
-In this case, no decision could be made as we had no semantic matches — so our route layer returned `None`! This feature is useful for creating fallback behavior or passthroughs in your applications when no intent is clearly matched.
+No route was close enough, so the router returns `None`. Treat that as your fallback signal: pass the query through, hand it to a default handler, whatever fits your app.

--- a/docs/user-guide/changelog.md
+++ b/docs/user-guide/changelog.md
@@ -95,7 +95,7 @@ The `0.1.10` release was primarily focused on expanding async support for `Qdran
 
 ### v0.1.9
 
-The `0.1.9` update focuses on improving support for our local deployment options. We have standardized the `PostgresIndex` to bring it in line with other index options and prepare it for future feature releases. For `local` extras (inclusing `transformers` and `llama_cpp` support) and `postgres` extras we have resolved issues making those extras unusable with Python 3.13.
+The `0.1.9` update focuses on improving support for our local deployment options. We have standardized the `PostgresIndex` to bring it in line with other index options and prepare it for future feature releases. For `local` extras (including `transformers` and `llama_cpp` support) and `postgres` extras we have resolved issues making those extras unusable with Python 3.13.
 
 Continue reading below for more detail.
 

--- a/docs/user-guide/components/encoders.md
+++ b/docs/user-guide/components/encoders.md
@@ -1,127 +1,120 @@
-Encoders are essential components in Semantic Router that transform text (or other data) into numerical representations that capture semantic meaning. These numerical representations, called embeddings, allow the system to measure semantic similarity between texts, which is the core functionality of the routing process.
+An encoder turns text (or images, or other data) into a vector — a list of numbers that captures meaning. Those vectors are what let Semantic Router measure how similar two inputs are. Every routing decision starts here.
 
-## Understanding Encoders
+## What an encoder does
 
-In Semantic Router, an encoder serves two primary purposes:
+An encoder does two jobs:
 
-1. **Convert utterances from routes into embeddings** during initialization
-2. **Convert incoming user queries into embeddings** during routing
+1. **At setup**, it embeds the example utterances in your routes.
+2. **At runtime**, it embeds each incoming query.
 
-By comparing these embeddings, Semantic Router can determine which route(s) best match the user's intent, even when the exact wording differs.
+The router compares the two and picks the closest route — even when the wording is completely different.
 
-## Dense vs. Sparse Encoders
+## Dense vs. sparse
 
-Semantic Router supports two main types of encoders:
+Semantic Router supports two kinds of encoder. They see text very differently, and each has its strengths.
 
-### Dense Encoders
+### Dense encoders
 
-Dense encoders generate embeddings where every dimension has a value, resulting in a "dense" vector. These encoders typically:
+Dense encoders fill every dimension of the vector. They:
 
-- Produce fixed-size vectors (e.g., 1536 dimensions for OpenAI's text-embedding-3-small)
-- Capture complex semantic relationships in the text
-- Perform well on tasks requiring understanding of context and meaning
-
-**Example usage**:
+- Produce fixed-size vectors (1536 dimensions for OpenAI's `text-embedding-3-small`, for example).
+- Capture rich semantic relationships.
+- Do well when context and meaning matter more than exact words.
 
 ```python
-from semantic_router.encoders import OpenAIEncoder
 import os
+from semantic_router.encoders import OpenAIEncoder
 
-# Set up API key
 os.environ["OPENAI_API_KEY"] = "your-api-key"
 
-# Initialize the encoder
 encoder = OpenAIEncoder()
-
-# Generate dense embeddings for documents
 embeddings = encoder(["How's the weather today?", "Tell me about politics"])
 ```
 
-### Sparse Encoders
+### Sparse encoders
 
-Sparse encoders generate embeddings where most dimensions are zero, with only a few dimensions having non-zero values. These encoders typically:
+Sparse encoders leave most dimensions at zero, with only a few non-zero values. They:
 
-- Focus on specific words or tokens in the text
-- Excel at keyword matching and term frequency
-- Can be more interpretable than dense encoders (non-zero dimensions often correspond to specific words)
-
-**Example usage**:
+- Key off specific words and tokens.
+- Excel at exact keyword matching and term frequency.
+- Are more interpretable — a non-zero dimension usually maps to a specific word.
 
 ```python
-from semantic_router.encoders import AurelioSparseEncoder
-from semantic_router import Route
 import os
+from semantic_router.encoders import AurelioSparseEncoder
 
-# Set up API key
 os.environ["AURELIO_API_KEY"] = "your-api-key"
 
-# Create some routes for routing
-routes = [
-    Route(name="weather", utterances=["How's the weather?", "Is it raining?"]),
-    Route(name="politics", utterances=["Tell me about politics", "Who's the president?"])
-]
-
-# Initialize the sparse encoder
 encoder = AurelioSparseEncoder()
-
-# Generate sparse embeddings for documents
 embeddings = encoder(["How's the weather today?", "Tell me about politics"])
 ```
 
-## Hybrid Approaches
+## Using both: hybrid routing
 
-Semantic Router also allows combining both dense and sparse encoders in a hybrid approach through the `HybridRouter`. This can leverage the strengths of both encoding methods:
+You don't have to choose. The `HybridRouter` takes a dense and a sparse encoder together, so you get semantic understanding *and* keyword precision. The `alpha` parameter sets the balance.
 
 ```python
+import os
+from semantic_router import Route
 from semantic_router.routers import HybridRouter
 from semantic_router.encoders import OpenAIEncoder, AurelioSparseEncoder
-import os
 
-# Set up API keys
 os.environ["OPENAI_API_KEY"] = "your-openai-api-key"
 os.environ["AURELIO_API_KEY"] = "your-aurelio-api-key"
 
-# Create dense and sparse encoders
-dense_encoder = OpenAIEncoder()
-sparse_encoder = AurelioSparseEncoder()
+routes = [
+    Route(name="weather", utterances=["How's the weather?", "Is it raining?"]),
+    Route(name="politics", utterances=["Tell me about politics", "Who's the president?"]),
+]
 
-# Initialize the hybrid router
 router = HybridRouter(
-    encoder=dense_encoder,
-    sparse_encoder=sparse_encoder,
+    encoder=OpenAIEncoder(),
+    sparse_encoder=AurelioSparseEncoder(),
     routes=routes,
-    alpha=0.5  # Balance between dense (0) and sparse (1) embeddings
+    alpha=0.5,  # 0 = all dense, 1 = all sparse
 )
 ```
 
-## Supported Encoders
+## Supported encoders
 
-### Dense Encoders
+Most encoders ship with the base install. The ones that run models locally need the `local` extra:
 
-| Encoder | Description | Installation |
-|---------|-------------|-------------|
-| [OpenAIEncoder](https://semantic-router.aurelio.ai/api/encoders/openai) | Uses OpenAI's text embedding models | `pip install -qU semantic-router` |
-| [AzureOpenAIEncoder](https://semantic-router.aurelio.ai/api/encoders/azure_openai) | Uses Azure OpenAI's text embedding models | `pip install -qU semantic-router` |
-| [CohereEncoder](https://semantic-router.aurelio.ai/api/encoders/cohere) | Uses Cohere's text embedding models | `pip install -qU semantic-router` |
-| [HuggingFaceEncoder](https://semantic-router.aurelio.ai/api/encoders/huggingface) | Uses local Hugging Face models | `pip install -qU "semantic-router[local]"` |
-| [HFEndpointEncoder](https://semantic-router.aurelio.ai/api/encoders/huggingface) | Uses Hugging Face Inference API | `pip install -qU semantic-router` |
-| [FastEmbedEncoder](https://semantic-router.aurelio.ai/api/encoders/fastembed) | Uses FastEmbed for local embeddings | `pip install -qU "semantic-router[local]"` |
-| [MistralEncoder](https://semantic-router.aurelio.ai/api/encoders/mistral) | Uses Mistral's text embedding models | `pip install -qU semantic-router` |
-| [GoogleEncoder](https://semantic-router.aurelio.ai/api/encoders/google) | Uses Google's text embedding models | `pip install -qU semantic-router` |
-| [BedrockEncoder](https://semantic-router.aurelio.ai/api/encoders/bedrock) | Uses AWS Bedrock embedding models | `pip install -qU semantic-router` |
-| [VitEncoder](https://semantic-router.aurelio.ai/api/encoders/vit) | Vision Transformer for image embeddings | `pip install -qU semantic-router` |
-| [CLIPEncoder](https://semantic-router.aurelio.ai/api/encoders/clip) | Uses CLIP for image embeddings | `pip install -qU semantic-router` |
+```bash
+pip install -qU "semantic-router[local]"
+```
 
-### Sparse Encoders
+### Dense encoders
 
-| Encoder | Description | Installation |
-|---------|-------------|-------------|
-| [BM25Encoder](https://semantic-router.aurelio.ai/api/encoders/bm25) | Implements BM25 algorithm for sparse embeddings | `pip install -qU semantic-router` |
-| [TfidfEncoder](https://semantic-router.aurelio.ai/api/encoders/tfidf) | Implements TF-IDF for sparse embeddings | `pip install -qU semantic-router` |
-| [AurelioSparseEncoder](https://semantic-router.aurelio.ai/api/encoders/aurelio) | Uses Aurelio's API for BM25 sparse embeddings | `pip install -qU semantic-router` |
-| **LocalSparseEncoder** | Uses local sentence-transformers SPLADE/CSR models for neural sparse embeddings | `pip install -qU "semantic-router[local]"` |
+| Encoder | What it uses | Install |
+|---------|--------------|---------|
+| [OpenAIEncoder](../../client-reference/encoders/openai) | OpenAI embedding models | base |
+| [AzureOpenAIEncoder](../../client-reference/encoders/azure_openai) | Azure OpenAI embedding models | base |
+| [CohereEncoder](../../client-reference/encoders/cohere) | Cohere embedding models | base |
+| [MistralEncoder](../../client-reference/encoders/mistral) | Mistral embedding models | base |
+| [GoogleEncoder](../../client-reference/encoders/google) | Google embedding models | base |
+| [BedrockEncoder](../../client-reference/encoders/bedrock) | AWS Bedrock embedding models | base |
+| [JinaEncoder](../../client-reference/encoders/jina) | Jina embedding models | base |
+| [VoyageEncoder](../../client-reference/encoders/voyage) | Voyage embedding models | base |
+| [NimEncoder](../../client-reference/encoders/nvidia_nim) | NVIDIA NIM embedding models | base |
+| [LiteLLMEncoder](../../client-reference/encoders/litellm) | Any provider supported by LiteLLM | base |
+| [OllamaEncoder](../../client-reference/encoders/ollama) | Embedding models served by a local Ollama instance | base |
+| [HFEndpointEncoder](../../client-reference/encoders/huggingface) | Hugging Face Inference API | base |
+| [HuggingFaceEncoder](../../client-reference/encoders/huggingface) | Hugging Face models, run locally | `local` |
+| [LocalEncoder](../../client-reference/encoders/local) | Any sentence-transformers model, run locally | `local` |
+| [FastEmbedEncoder](../../client-reference/encoders/fastembed) | FastEmbed models, run locally | `local` |
+| [VitEncoder](../../client-reference/encoders/vit) | Vision Transformer, for image embeddings | `local` |
+| [CLIPEncoder](../../client-reference/encoders/clip) | CLIP, for image and text embeddings | `local` |
 
-**Example usage:**
+### Sparse encoders
+
+| Encoder | What it uses | Install |
+|---------|--------------|---------|
+| [BM25Encoder](../../client-reference/encoders/bm25) | BM25 | base |
+| [TfidfEncoder](../../client-reference/encoders/tfidf) | TF-IDF | base |
+| [AurelioSparseEncoder](../../client-reference/encoders/aurelio) | Aurelio's API for BM25 sparse embeddings | base |
+| [LocalSparseEncoder](../../client-reference/encoders/local) | Neural sparse models (SPLADE, CSR) via sentence-transformers, run locally | `local` |
+
+`LocalSparseEncoder` is worth a closer look if you want sparse vectors without an API. It uses the sentence-transformers `SparseEncoder` API (v5+), runs on CPU, CUDA, or MPS, and works with any compatible model from the Hugging Face Hub:
 
 ```python
 from semantic_router.encoders import LocalSparseEncoder
@@ -130,33 +123,26 @@ encoder = LocalSparseEncoder(name="naver/splade-v3")
 embeddings = encoder(["How's the weather today?", "Tell me about politics"])
 ```
 
-- This encoder uses sentence-transformers >=v5's SparseEncoder API to generate high-dimensional sparse vectors (e.g., SPLADE, CSR).
-- No API key required; all computation is local (CPU, CUDA, or MPS).
-- You can use any compatible sparse model from the Hugging Face Hub (e.g., naver/splade-v3, mixedbread-ai/mxbai-embed-large-v1, etc.).
+## AutoEncoder
 
-## Using AutoEncoder
-
-Semantic Router provides an `AutoEncoder` class that automatically selects the appropriate encoder based on the specified type:
+If you'd rather pick an encoder by name at runtime, `AutoEncoder` resolves the right class for you:
 
 ```python
 from semantic_router.encoders import AutoEncoder
 from semantic_router.schema import EncoderType
 
-# Create an encoder based on type
 encoder = AutoEncoder(type=EncoderType.OPENAI.value, name="text-embedding-3-small").model
-
-# Use the encoder
 embeddings = encoder(["How can I help you today?"])
 ```
 
-## Considerations for Choosing an Encoder
+## Choosing an encoder
 
-When selecting an encoder for your application, consider:
+A few questions to ask:
 
-1. **Accuracy**: Dense encoders typically provide better semantic understanding but may miss exact keyword matches
-2. **Speed**: Local encoders are faster but may be less accurate than cloud-based ones
-3. **Cost**: Cloud-based encoders (OpenAI, Cohere, Aurelio AI) incur API costs
-4. **Privacy**: Local encoders keep data within your environment
-5. **Use case**: Hybrid approaches may work best for balanced retrieval
+1. **Accuracy.** Dense encoders understand meaning better but can miss exact keywords. Sparse encoders are the reverse.
+2. **Speed.** Local encoders avoid network round-trips, though cloud models are often more accurate.
+3. **Cost.** Cloud encoders (OpenAI, Cohere, Aurelio) bill per call. Local ones don't.
+4. **Privacy.** Local encoders keep your data on your machine.
+5. **Both?** When you're unsure, a hybrid setup often gives the best balance.
 
-For more detailed information on specific encoders, refer to their respective documentation pages. 
+Each encoder's reference page covers its specific options.

--- a/docs/user-guide/components/indexes.md
+++ b/docs/user-guide/components/indexes.md
@@ -1,182 +1,152 @@
-Indexes are critical components in Semantic Router that store and retrieve embeddings efficiently. They act as the search backend that enables Semantic Router to find the most relevant routes for incoming queries.
+An index is where Semantic Router stores your route embeddings and searches them. It's the search backend behind every routing decision.
 
-## Understanding Indexes
+## What an index does
 
-In Semantic Router, an index serves several key purposes:
+An index handles four things:
 
-1. **Store embeddings** of route utterances
-2. **Search for similar vectors** when routing queries
-3. **Persist route configurations** across sessions
-4. **Scale to handle large numbers** of routes and utterances
+1. **Stores** the embeddings of your route utterances.
+2. **Searches** for the most similar vectors when a query comes in.
+3. **Persists** your routes across sessions (remote indexes only).
+4. **Scales** to large numbers of routes and utterances.
 
-The choice of index can significantly impact the performance, scalability, and persistence capabilities of your semantic routing system.
+Your choice of index shapes performance, scale, and whether your routes survive a restart.
 
-## Local vs. Remote Indexes
+## Local vs. remote
 
-Semantic Router supports both local (in-memory) and remote (cloud-based) indexes:
+### Local indexes
 
-### Local Indexes
-
-Local indexes store embeddings in memory, making them fast but ephemeral. They're perfect for development, testing, or applications with a small number of routes.
-
-**Example usage**:
+A local index keeps embeddings in memory. It's fast and needs zero setup, but it's gone when your process exits. Ideal for development, testing, and small route sets.
 
 ```python
-from semantic_router.index import LocalIndex
-from semantic_router.routers import SemanticRouter
-from semantic_router.encoders import OpenAIEncoder
 import os
+from semantic_router import Route, SemanticRouter
+from semantic_router.encoders import OpenAIEncoder
+from semantic_router.index import LocalIndex
 
-# Set up API key
 os.environ["OPENAI_API_KEY"] = "your-api-key"
 
-# Create routes
-from semantic_router import Route
 routes = [
     Route(name="weather", utterances=["How's the weather?", "Is it raining?"]),
-    Route(name="politics", utterances=["Tell me about politics", "Who's the president?"])
+    Route(name="politics", utterances=["Tell me about politics", "Who's the president?"]),
 ]
 
-# Initialize the local index
-index = LocalIndex()
-
-# Create a router with the local index
 router = SemanticRouter(
     encoder=OpenAIEncoder(),
     routes=routes,
-    index=index
+    index=LocalIndex(),
 )
 
-# Use the router
 result = router("What's the weather like today?")
 print(result.name)  # "weather"
 ```
 
-### Remote Indexes
+### Remote indexes
 
-Remote indexes store embeddings in cloud-based vector databases, making them persistent and scalable. They're ideal for production applications or systems with many routes.
+A remote index stores embeddings in a vector database. Your routes persist, and you can scale to millions of vectors. This is what you want in production.
 
-**Example usage with Pinecone**:
+Here's Pinecone:
 
 ```python
-from semantic_router.index import PineconeIndex
-from semantic_router.routers import SemanticRouter
-from semantic_router.encoders import OpenAIEncoder
 import os
+from semantic_router import Route, SemanticRouter
+from semantic_router.encoders import OpenAIEncoder
+from semantic_router.index import PineconeIndex
 
-# Set up API keys
 os.environ["OPENAI_API_KEY"] = "your-openai-api-key"
 os.environ["PINECONE_API_KEY"] = "your-pinecone-api-key"
 
-# Create routes
-from semantic_router import Route
 routes = [
     Route(name="weather", utterances=["How's the weather?", "Is it raining?"]),
-    Route(name="politics", utterances=["Tell me about politics", "Who's the president?"])
+    Route(name="politics", utterances=["Tell me about politics", "Who's the president?"]),
 ]
 
-# Initialize the Pinecone index
 index = PineconeIndex(
     index_name="semantic-router",
-    dimensions=1536  # Must match your encoder's dimension
+    dimensions=1536,  # must match your encoder
 )
 
-# Create a router with the Pinecone index
 router = SemanticRouter(
     encoder=OpenAIEncoder(),
     routes=routes,
     index=index,
-    auto_sync="remote"  # Automatically sync routes to remote index
+    auto_sync="remote",  # push local routes to the remote index
 )
 
-# Use the router
 result = router("What's the weather like today?")
 print(result.name)  # "weather"
 ```
 
-## Hybrid Indexes
+## Hybrid indexes
 
-For advanced use cases, Semantic Router also provides a hybrid index that combines both dense and sparse embeddings:
+For hybrid routing, you need an index that stores both dense and sparse vectors. `HybridLocalIndex` does that in memory:
 
 ```python
-from semantic_router.index import HybridLocalIndex
+import os
 from semantic_router.routers import HybridRouter
 from semantic_router.encoders import OpenAIEncoder, AurelioSparseEncoder
-import os
+from semantic_router.index import HybridLocalIndex
 
-# Set up API keys
 os.environ["OPENAI_API_KEY"] = "your-openai-api-key"
 os.environ["AURELIO_API_KEY"] = "your-aurelio-api-key"
 
-# Initialize dense and sparse encoders
-dense_encoder = OpenAIEncoder()
-sparse_encoder = AurelioSparseEncoder()
-
-# Create a hybrid index
-index = HybridLocalIndex()
-
-# Create a hybrid router
 router = HybridRouter(
-    encoder=dense_encoder,
-    sparse_encoder=sparse_encoder,
+    encoder=OpenAIEncoder(),
+    sparse_encoder=AurelioSparseEncoder(),
     routes=routes,
-    index=index,
-    alpha=0.5  # Balance between dense (0) and sparse (1) embeddings
+    index=HybridLocalIndex(),
+    alpha=0.5,  # 0 = all dense, 1 = all sparse
 )
 ```
 
-## Supported Indexes
+## Supported indexes
 
-| Index | Description | Installation |
-|-------|-------------|-------------|
-| [LocalIndex](https://semantic-router.aurelio.ai/api/index/local) | In-memory index for development and testing | `pip install -qU semantic-router` |
-| [HybridLocalIndex](https://semantic-router.aurelio.ai/api/index/hybrid_local) | In-memory index supporting hybrid search | `pip install -qU "semantic-router[hybrid]"` |
-| [PineconeIndex](https://semantic-router.aurelio.ai/api/index/pinecone) | Pinecone vector database integration | `pip install -qU "semantic-router[pinecone]"` |
-| [QdrantIndex](https://semantic-router.aurelio.ai/api/index/qdrant) | Qdrant vector database integration | `pip install -qU "semantic-router[qdrant]"` |
-| [PostgresIndex](https://semantic-router.aurelio.ai/api/index/postgres) | PostgreSQL with pgvector extension | `pip install -qU "semantic-router[postgres]"` |
+| Index | What it is | Install |
+|-------|------------|---------|
+| [LocalIndex](../../client-reference/index/local) | In-memory, for development and testing | base |
+| [HybridLocalIndex](../../client-reference/index/hybrid_local) | In-memory, dense and sparse | base |
+| [PineconeIndex](../../client-reference/index/pinecone) | Pinecone vector database | `pip install -qU "semantic-router[pinecone]"` |
+| [QdrantIndex](../../client-reference/index/qdrant) | Qdrant vector database | `pip install -qU "semantic-router[qdrant]"` |
+| [PostgresIndex](../../client-reference/index/postgres) | PostgreSQL with pgvector | `pip install -qU "semantic-router[postgres]"` |
 
-## Auto-Sync Feature
+## Keeping local and remote in sync
 
-Semantic Router provides an auto-sync feature that keeps your routes in sync between local and remote indexes:
+With a remote index, your in-memory routes and the stored ones can drift. The `auto_sync` parameter tells the router how to reconcile them at startup:
 
 ```python
-# Initialize router with auto-sync to remote index
 router = SemanticRouter(
     encoder=encoder,
     routes=routes,
     index=remote_index,
-    auto_sync="remote"  # Options: "local", "remote", None
+    auto_sync="remote",  # "local", "remote", or None
 )
 
-# Add a new route - it will be automatically synced to the remote index
-new_route = Route(name="greetings", utterances=["Hello there", "Hi, how are you?"])
-router.add(new_route)
+# adding a route syncs it automatically
+router.add(Route(name="greetings", utterances=["Hello there", "Hi, how are you?"]))
 ```
 
-Auto-sync modes:
-- `"local"`: Sync from remote to local (pull)
-- `"remote"`: Sync from local to remote (push)
-- `None`: No automatic syncing
+- `"local"` — local is the source of truth; push it to remote.
+- `"remote"` — remote is the source of truth; pull it into local.
+- `None` — don't sync.
 
-## Considerations for Choosing an Index
+There are more strategies, including merges. The [sync guide](../features/sync) covers them all.
 
-When selecting an index for your application, consider:
+## Choosing an index
 
-1. **Persistence**: Local indexes are lost when your application restarts; remote indexes persist
-2. **Scalability**: Remote indexes can handle millions of vectors; local indexes are limited by memory
-3. **Latency**: Local indexes have lower latency; remote indexes add network overhead
-4. **Setup complexity**: Local indexes require no setup; remote indexes require account creation and configuration
-5. **Cost**: Local indexes are free; remote indexes may incur usage costs
-6. **Hybrid search**: Only certain indexes support combined dense and sparse search
+1. **Persistence.** Local indexes vanish on restart. Remote ones don't.
+2. **Scale.** Local is bounded by memory. Remote handles millions of vectors.
+3. **Latency.** Local is fastest. Remote adds a network hop.
+4. **Setup.** Local needs nothing. Remote needs an account and config.
+5. **Cost.** Local is free. Remote may bill for usage.
+6. **Hybrid search.** Only some indexes store both dense and sparse vectors.
 
-## Index Methods
+## Index methods
 
-All indexes in Semantic Router inherit from `BaseIndex` and implement these key methods:
+Every index inherits from `BaseIndex` and implements:
 
-- `add()`: Add embeddings to the index
-- `query()`: Search for similar vectors
-- `delete()`: Remove routes from the index
-- `describe()`: Get information about the index
-- `is_ready()`: Check if the index is initialized and ready for use
+- `add()` — add embeddings.
+- `query()` — search for similar vectors.
+- `delete()` — remove a route.
+- `describe()` — get index info.
+- `is_ready()` — check it's initialized.
 
-For detailed information on specific indexes and their configuration options, refer to their respective documentation pages. 
+Each index's reference page covers its configuration options.

--- a/docs/user-guide/components/routers.md
+++ b/docs/user-guide/components/routers.md
@@ -1,219 +1,170 @@
-=Routers are the core components of Semantic Router that actually perform the intelligent routing of text to the appropriate handlers. They combine encoders and indexes to create a powerful semantic classification system.
+The router is the part you actually talk to. It takes a query, finds the best-matching route, and hands back a decision. Under the hood it wires together an encoder, an index, and your routes.
 
-## Understanding Routers
+## What a router does
 
-In Semantic Router, routers serve several key functions:
+1. **Encodes** incoming queries.
+2. **Matches** them to routes by similarity.
+3. **Decides** which handler should run.
+4. **Manages** routes — add, look up, list.
+5. **Reports** a confidence score with each decision.
 
-1. **Process incoming queries** into semantic representations
-2. **Match queries to routes** based on similarity
-3. **Make decisions** about which handler should process a query
-4. **Manage routes** (adding, updating, removing)
-5. **Provide confidence scores** for routing decisions
-
-The router is the main interface you'll interact with when using Semantic Router, as it brings together all the other components (routes, encoders, and indexes) into a cohesive system.
-
-## Router Types
-
-Semantic Router provides two main types of routers:
+## Router types
 
 ### SemanticRouter
 
-The `SemanticRouter` is the standard router that uses dense embeddings to match queries to routes. It's the most common and widely used router type.
-
-**Example usage**:
+The standard router. It uses dense embeddings and is what most people reach for first.
 
 ```python
-from semantic_router.routers import SemanticRouter
+import os
+from semantic_router import Route, SemanticRouter
 from semantic_router.encoders import OpenAIEncoder
 from semantic_router.index import LocalIndex
-from semantic_router import Route
-import os
 
-# Set up API key
 os.environ["OPENAI_API_KEY"] = "your-api-key"
 
-# Create routes
 routes = [
     Route(name="weather", utterances=["How's the weather?", "Is it raining?"]),
-    Route(name="politics", utterances=["Tell me about politics", "Who's the president?"])
+    Route(name="politics", utterances=["Tell me about politics", "Who's the president?"]),
 ]
 
-# Initialize the router
 router = SemanticRouter(
     encoder=OpenAIEncoder(),
     routes=routes,
-    index=LocalIndex()
+    index=LocalIndex(),
 )
 
-# Use the router to route a query
 result = router("What's the weather like today?")
-print(result.name)  # "weather"
-print(result.score) # e.g., 0.92
+print(result.name)   # "weather"
+print(result.score)  # e.g. 0.92
 ```
 
 ### HybridRouter
 
-The `HybridRouter` uses both dense and sparse embeddings for a more balanced approach, combining semantic understanding with keyword matching. This can improve accuracy in many cases, especially where exact keyword matching is important.
-
-**Example usage**:
+The `HybridRouter` combines dense and sparse embeddings — semantic understanding plus keyword matching. It often wins when your queries carry specific terms that need to match exactly.
 
 ```python
+import os
+from semantic_router import Route
 from semantic_router.routers import HybridRouter
 from semantic_router.encoders import OpenAIEncoder, AurelioSparseEncoder
 from semantic_router.index import HybridLocalIndex
-from semantic_router import Route
-import os
 
-# Set up API keys
 os.environ["OPENAI_API_KEY"] = "your-openai-api-key"
 os.environ["AURELIO_API_KEY"] = "your-aurelio-api-key"
 
-# Create routes
 routes = [
     Route(name="weather", utterances=["How's the weather?", "Is it raining?"]),
-    Route(name="politics", utterances=["Tell me about politics", "Who's the president?"])
+    Route(name="politics", utterances=["Tell me about politics", "Who's the president?"]),
 ]
 
-# Initialize the router with both dense and sparse encoders
 router = HybridRouter(
     encoder=OpenAIEncoder(),
     sparse_encoder=AurelioSparseEncoder(),
     routes=routes,
     index=HybridLocalIndex(),
-    alpha=0.3  # Balance between dense (0) and sparse (1) embeddings
+    alpha=0.3,  # 0 = all dense, 1 = all sparse
 )
 
-# Use the router 
 result = router("What's the weather like today?")
 print(result.name)  # "weather"
 ```
 
-## Key Router Features
+## Working with routes
 
-### Route Management
-
-Routers make it easy to add, update, and manage routes:
+Add, fetch, and list routes on a live router:
 
 ```python
-# Adding a new route
-new_route = Route(name="greetings", utterances=["Hello there", "Hi, how are you?"])
-router.add(new_route)
+router.add(Route(name="greetings", utterances=["Hello there", "Hi, how are you?"]))
 
-# Getting a route by name
 greeting_route = router.get("greetings")
-
-# Listing all route names
 route_names = router.list_route_names()
 ```
 
-### Threshold Control
+## Thresholds
 
-Control the sensitivity of your router by setting score thresholds:
+A route only matches when its similarity score clears a threshold. Set one for the whole router, or per route:
 
 ```python
-# Global threshold for all routes
+# one threshold for every route
 router = SemanticRouter(
     encoder=OpenAIEncoder(),
     routes=routes,
-    score_threshold=0.75  # Only match if similarity is above 0.75
+    score_threshold=0.75,
 )
 
-# Per-route threshold
+# a stricter threshold on one route
 weather_route = Route(
-    name="weather", 
+    name="weather",
     utterances=["How's the weather?", "Is it raining?"],
-    score_threshold=0.8  # Higher threshold for this specific route
+    score_threshold=0.8,
 )
 ```
 
-### Asynchronous Operation
+Picking thresholds by hand is tedious. The [threshold optimization guide](../features/threshold-optimization) shows how to fit them from examples in seconds.
 
-Both router types support asynchronous operation for improved performance in async environments:
+## Async
+
+Both routers work in async code:
 
 ```python
-# Async routing
 result = await router.acall("What's the weather like today?")
-
-# Async route addition
 await router.aadd(new_route)
 ```
 
-### Loading from Configuration
+## Loading from config
 
-Routers can be loaded from configurations for easier deployment across environments:
+Load a router from a file or a config object — handy for shipping the same routes across environments:
 
 ```python
-# Create a router from a YAML configuration file
+# from YAML
 router = SemanticRouter.from_yaml("router_config.yaml")
 
-# Or from a RouterConfig object
+# from a RouterConfig
 from semantic_router.routers import RouterConfig
 
 config = RouterConfig(routes=routes, encoder_type="openai")
 router = SemanticRouter.from_config(config)
 ```
 
-## Considerations for Choosing a Router
+## Syncing with a remote index
 
-When selecting a router for your application, consider:
-
-1. **Accuracy requirements**: HybridRouter typically provides better accuracy by combining semantic and keyword matching
-2. **Performance needs**: SemanticRouter is more lightweight and can be faster
-3. **Query characteristics**: If your queries often contain specific keywords, HybridRouter may perform better
-4. **Resource constraints**: HybridRouter requires more computational resources
-5. **Infrastructure**: Make sure you have the required API keys for the encoders used by your selected router
-
-## Advanced Usage: Auto-Sync
-
-Both router types support syncing routes between local and remote indexes:
+With a remote index, `auto_sync` controls how local and stored routes are reconciled:
 
 ```python
-# Initialize router with auto-sync to remote index
 router = SemanticRouter(
     encoder=encoder,
     routes=routes,
     index=remote_index,
-    auto_sync="remote"  # Options: "local", "remote", None
+    auto_sync="remote",  # "local", "remote", or None
 )
 ```
 
-## Advanced Usage: Hybrid Alpha
+The [sync guide](../features/sync) covers every strategy.
 
-The `HybridRouter` allows fine-tuning the balance between dense and sparse embeddings:
+## Tuning hybrid alpha
+
+`alpha` sets the dense/sparse balance in a `HybridRouter`:
 
 ```python
-# More weight to dense embeddings (semantic matching)
-router = HybridRouter(
-    encoder=OpenAIEncoder(),
-    sparse_encoder=AurelioSparseEncoder(),
-    routes=routes,
-    alpha=0.2  # 80% dense, 20% sparse
-)
-
-# Equal weight to both
-router = HybridRouter(
-    encoder=OpenAIEncoder(),
-    sparse_encoder=AurelioSparseEncoder(),
-    routes=routes,
-    alpha=0.5  # 50% dense, 50% sparse
-)
-
-# More weight to sparse embeddings (keyword matching)
-router = HybridRouter(
-    encoder=OpenAIEncoder(),
-    sparse_encoder=AurelioSparseEncoder(),
-    routes=routes,
-    alpha=0.8  # 20% dense, 80% sparse
-)
+alpha=0.2  # lean semantic (80% dense, 20% sparse)
+alpha=0.5  # even split
+alpha=0.8  # lean keywords (20% dense, 80% sparse)
 ```
 
-## Router Return Values
+## What a router returns
 
-When you call a router with a query, it returns a `RouteChoice` object with these key attributes:
+Calling a router gives you a `RouteChoice` with:
 
-- `name`: The name of the matched route (or empty string if no match)
-- `score`: The confidence score of the match
-- `function_schema`: Optional function schema associated with the route
-- `metadata`: Any additional metadata associated with the route
+- `name` — the matched route, or `None` if nothing matched.
+- `score` — the confidence of the match.
+- `function_call` — for dynamic routes, the function(s) to call and their arguments.
+- `metadata` — any metadata attached to the route.
 
-For detailed information on routers and their configuration options, refer to the API documentation. 
+## SemanticRouter or HybridRouter?
+
+- **HybridRouter** usually scores higher, because it matches on meaning *and* keywords.
+- **SemanticRouter** is lighter and faster.
+- If your queries contain specific terms that must match exactly — product codes, names, jargon — go hybrid.
+- Hybrid needs a sparse encoder too, so check you have the API keys or local models it needs.
+
+The API reference has the full detail on every option.

--- a/docs/user-guide/concepts/architecture.md
+++ b/docs/user-guide/concepts/architecture.md
@@ -1,8 +1,8 @@
 # Semantic Router: Technical Architecture
 
-## System Overview
+## System overview
 
-Semantic Router is built around three core components that work together to enable intelligent routing of inputs based on semantic meaning.
+Three components do the work. An **encoder** turns the input into a vector. An **index** stores your route vectors. A **router** compares the two and picks a match.
 
 ```mermaid
 graph TD
@@ -15,11 +15,11 @@ graph TD
     G --> H[Response Handler]
 ```
 
-## Core Components
+## Core components
 
 ### 1. Encoders
 
-Encoders transform inputs into vector representations in semantic space.
+Encoders map inputs into semantic space.
 
 ```mermaid
 classDiagram
@@ -43,14 +43,13 @@ classDiagram
     SparseEncoder <|-- TFIDFEncoder
 ```
 
-**Types of Encoders:**
-- **Dense encoders**: Generate continuous vectors (OpenAI, HuggingFace, etc.)
-- **Sparse encoders**: Generate sparse vectors (BM25, TFIDF, AurelioSparse, etc.)
-- **Multimodal encoders**: Handle images and text (CLIP, ViT)
+- **Dense encoders** produce continuous vectors (OpenAI, Hugging Face, …).
+- **Sparse encoders** produce mostly-zero vectors (BM25, TF-IDF, AurelioSparse, …).
+- **Multimodal encoders** handle images as well as text (CLIP, ViT).
 
 ### 2. Routes
 
-Routes define patterns to match against, with examples of inputs that should trigger them.
+A route is a pattern to match, defined by example inputs that should trigger it.
 
 ```mermaid
 classDiagram
@@ -64,15 +63,14 @@ classDiagram
     }
 ```
 
-**Key properties:**
-- **name**: Identifier for the route
-- **utterances**: Example inputs that should match this route
-- **function_schemas**: Optional specifications for function calling
-- **score_threshold**: Minimum similarity score required to match
+- **name** — the route's identifier.
+- **utterances** — example inputs that should match.
+- **function_schemas** — optional. Set this and the route becomes *dynamic*, able to call functions.
+- **score_threshold** — the minimum similarity needed to match.
 
-### 3. Indexing Systems
+### 3. Indexes
 
-Indexes store and retrieve route vectors efficiently.
+Indexes store route vectors and search them efficiently.
 
 ```mermaid
 classDiagram
@@ -88,13 +86,12 @@ classDiagram
     LocalIndex <|-- HybridLocalIndex
 ```
 
-**Index types:**
-- **LocalIndex**: In-memory vector storage for dense embeddings
-- **HybridLocalIndex**: In-memory storage supporting both dense and sparse vectors
-- **PineconeIndex/QdrantIndex**: Cloud-based vector DBs
-- **PostgresIndex**: SQL-based vector storage
+- **LocalIndex** — in-memory, dense vectors.
+- **HybridLocalIndex** — in-memory, dense *and* sparse.
+- **PineconeIndex / QdrantIndex** — cloud vector databases.
+- **PostgresIndex** — SQL storage via pgvector.
 
-## Data Flow
+## Data flow
 
 ```mermaid
 sequenceDiagram
@@ -110,13 +107,13 @@ sequenceDiagram
     Router->>User: return best matched route
 ```
 
-1. **Input Reception**: The system receives an input (text, image)
-2. **Encoding**: The input is transformed into a vector representation
-3. **Retrieval**: The vector is compared against stored route vectors
-4. **Matching**: The best matching route is selected based on similarity
-5. **Response**: The system returns the matched route, enabling appropriate handling
+1. An input arrives (text, an image).
+2. The encoder turns it into a vector.
+3. The router searches the index for similar route vectors.
+4. The best match above threshold is selected.
+5. The matched route comes back, ready for your handler.
 
-## Router Types
+## Router types
 
 ```mermaid
 classDiagram
@@ -130,10 +127,10 @@ classDiagram
     BaseRouter <|-- HybridRouter
 ```
 
-- **SemanticRouter**: Uses dense vector embeddings for semantic matching
-- **HybridRouter**: Combines both dense and sparse vectors for enhanced accuracy
+- **SemanticRouter** — dense embeddings, pure semantic matching.
+- **HybridRouter** — dense *and* sparse, for better accuracy when exact keywords matter.
 
-## Integration Example
+## Putting it together
 
 ```python
 from semantic_router import Route, SemanticRouter
@@ -143,21 +140,20 @@ from semantic_router.encoders import OpenAIEncoder
 weather_route = Route(name="weather", utterances=["What's the weather like?"])
 greeting_route = Route(name="greeting", utterances=["Hello there!", "Hi!"])
 
-# 2. Initialize encoder
+# 2. Pick an encoder
 encoder = OpenAIEncoder()
 
-# 3. Create router with routes
+# 3. Build the router
 router = SemanticRouter(encoder=encoder, routes=[weather_route, greeting_route])
 
-# 4. Route an incoming query
+# 4. Route a query
 result = router("What's the forecast for tomorrow?")
 print(result.name)  # "weather"
 ```
 
-## Performance Considerations
+## Performance notes
 
-- **In-memory vs. Vector DB**: Choose based on scale and latency requirements
-- **Encoder selection**: Balance accuracy vs. speed based on use case
-- **Batch processing**: Use batch methods for higher throughput
-- **Async support**: Available for high-concurrency environments and applications relying
-on heavy network use
+- **In-memory vs. vector DB** — pick by scale and latency needs.
+- **Encoder choice** — trade accuracy against speed for your use case.
+- **Batching** — use the batch methods for higher throughput.
+- **Async** — available for high-concurrency and network-heavy workloads.

--- a/docs/user-guide/concepts/overview.md
+++ b/docs/user-guide/concepts/overview.md
@@ -1,19 +1,18 @@
-Semantic Routing is an approach to directing inputs (like text, images, or audio) to the appropriate handlers based on their meaning rather than rigid keyword matching or rule-based systems. It provides a more flexible and human-like understanding of content, allowing systems to gracefully handle the natural variability in how people express similar ideas.
+Semantic routing sends an input — text, an image, audio — to the right handler based on what it *means*, not on keywords or hand-written rules. People say the same thing a hundred different ways. Semantic routing handles that variety without you enumerating every phrasing.
 
-## Semantic Space
+## Semantic space
 
-Semantic space is a high-dimensional mathematical space where meaning is represented geometrically. Imagine a vast coordinate system where every point corresponds to a specific concept or idea. In this space, the sentence "I need help with my password" exists as a point near "Can't log in to my account" but far from "What's the weather forecast?" Semantic similarity becomes a measurable distance, transforming abstract meaning into computable relationships.
+Here's the core idea. Imagine a huge coordinate system where every point is a concept. "I need help with my password" sits right next to "Can't log in to my account", and far from "What's the weather forecast?". That's semantic space. Meaning becomes geometry, and similarity becomes a distance you can measure.
 
-- Each point (vector) represents the meaning of a piece of content
-- Distance between points represents semantic difference
-- Content with similar meanings cluster together, regardless of exact wording
+- Each point (a vector) represents the meaning of some content.
+- Distance between points is semantic difference.
+- Similar meanings cluster together, whatever the exact wording.
 
-This approach allows us to capture the nuanced relationships between concepts, accommodating synonyms, paraphrases, and related ideas without explicitly programming each variation.
+So synonyms, paraphrases, and related ideas all land close to each other — and you never program the variations by hand.
 
 ### Encoders
 
-To place content in a semantic space, we need to convert it into vector representations – a process called **encoding**. This is handled by neural network models called **bi-encoders** (commonly known as embedding
-models or encoders) which:
+To put content into semantic space, you *encode* it into a vector. That's the job of an encoder (you'll also hear "embedding model" or "bi-encoder").
 
 ```mermaid
 flowchart LR
@@ -25,44 +24,40 @@ flowchart LR
     style C fill:#f1f8e9,stroke:#558b2f,stroke-width:1px
 ```
 
-1. Process the input content (text, image, etc.)
-2. Analyze its features and semantic properties
-3. Output a fixed-size vector of floating-point numbers (typically hundreds or thousands of dimensions)
+An encoder takes the input, analyzes its features, and outputs a fixed-size vector of numbers — usually hundreds or thousands of dimensions. "How's the weather today?" might become `[0.12, -0.34, 0.56, ...]`. "What's the temperature outside?" becomes a different but nearby vector, because the meanings are close.
 
-For example, the sentence "How's the weather today?" might be encoded as a vector like `[0.12, -0.34, 0.56, ...]`, while "What's the temperature outside?" would produce a different but nearby vector, reflecting their similar meanings.
+Semantic Router supports two families:
 
-Semantic Router supports various encoder types:
+- **Dense encoders** (`OpenAIEncoder`, `HuggingFaceEncoder`, …) fill every dimension. They capture rich semantic relationships.
+- **Sparse encoders** (`AurelioSparseEncoder`, `BM25Encoder`, …) leave most dimensions at zero. They excel at exact keywords and term frequency.
 
-- **Dense encoders** (like `OpenAIEncoder` or `HuggingFaceEncoder`): Generate vectors where every dimension has a value, capturing complex semantic relationships
-- **Sparse encoders** (like `AurelioSparseEncoder` or `BM25Encoder`): Generate vectors where most dimensions are zero, excelling at keyword matching and term frequency
+### Multimodal routing
 
-### Multimodal Routing
+Text is the common case, but anything you can encode, you can route:
 
-While text is the most common application, semantic routing works with any content that can be meaningfully encoded into vectors:
+- **Images.** `CLIPEncoder` and `VitEncoder` place images in the same space as text, so you can compare across modalities.
+- **Audio.** Speech or sound, routed on content or tone.
+- **Mixed content.** Text and images together, encoded jointly or separately.
 
-- **Images**: Using encoders like `CLIPEncoder` or `VitEncoder`, images can be placed in the same semantic space as text, enabling cross-modal comparisons and routing
-- **Audio**: Speech or sound can be encoded and routed based on content, tone, or other semantic attributes
-- **Hybrid content**: Combinations of text, images, and other modalities can be encoded together or separately
+That's what lets you route on what's *in* an image, or on the combined meaning of text plus a picture.
 
-This multimodal capability enables powerful applications like routing based on the content of images, or understanding the combined meaning of text and images together.
+### Making the decision
 
-### Making Routing Decisions
-
-Once content is encoded into vectors, **semantic similarity** is used to make routing decisions. This is typically calculated using mathematical operations like:
+Once everything is a vector, routing is a similarity calculation. The usual measures:
 
 - **Cosine similarity**: cos(θ) = (A·B)/(||A||·||B||)
 - **Euclidean distance**: d(A,B) = √(Σ(Aᵢ-Bᵢ)²)
 - **Dot product**: A·B = Σ(Aᵢ·Bᵢ)
 
-Semantic Router compares incoming queries against predefined routes, each represented by one or more example utterances. The route with the highest similarity score above a configurable threshold is selected as the match.
+Semantic Router compares the incoming query against every route, where each route is represented by its example utterances. The route with the highest score above a configurable threshold wins.
 
-## Implementation Workflow
+## The workflow
 
-1. **Define routes**: Create example utterances for each target category
-2. **Select encoder**: Choose based on content type and performance requirements
-3. **Configure router**: Connect encoder, routes, and vector index
-4. **Implement handlers**: Define logic for each route
-5. **Process inputs**: Transform, encode, and route based on similarity
+1. **Define routes** — example utterances for each category.
+2. **Pick an encoder** — based on content type and performance needs.
+3. **Configure the router** — connect encoder, routes, and an index.
+4. **Write handlers** — the logic for each route.
+5. **Route inputs** — encode, compare, dispatch.
 
 ```mermaid
 flowchart TD
@@ -89,13 +84,4 @@ flowchart TD
     class F,G,H,I,J,K runtime
 ```
 
-## Getting Started with Semantic Router
-
-Semantic Router makes implementing these capabilities straightforward:
-
-1. **Define routes** with example utterances representing the concepts you want to detect
-2. **Choose an encoder** appropriate for your content type and requirements
-3. **Initialize a router** that connects your encoder, routes, and an index for storing embeddings
-4. **Route incoming content** to appropriate handlers based on semantic similarity
-
-The library handles the complex vector operations, similarity calculations, and decision-making process, allowing you to focus on defining meaningful routes and creating effective handlers for each case.
+Semantic Router handles the vector math, the similarity scoring, and the decision. You focus on defining good routes and writing the handlers.

--- a/docs/user-guide/features/dynamic-routes.md
+++ b/docs/user-guide/features/dynamic-routes.md
@@ -1,18 +1,15 @@
-In semantic-router there are two types of routes that can be chosen. Both routes belong to the `Route` object, the only difference between them is that *static* routes return a `Route.name` when chosen, whereas *dynamic* routes use an LLM call to produce parameter input values.
+There are two kinds of route. A *static* route tells you which route matched — you get back its name, like `"math"`. A *dynamic* route does that too, but it also pulls the details out of the query and hands them to a function.
 
-For example, a *static* route will tell us if a query is talking about mathematics by returning the route name (which could be `"math"` for example). A *dynamic* route does the same thing, but it also extracts key information from the input utterance to be used in a function associated with that route.
-
-For example we could provide a dynamic route with associated utterances:
+Say you have a route with utterances like these:
 
 ```python
 "what is x to the power of y?"
 "what is 9 to the power of 4?"
 "calculate the result of base x and exponent y"
-"calculate the result of base 10 and exponent 3"
 "return x to the power of y"
 ```
 
-and we could also provide the route with a schema outlining key features of the function:
+and you attach a function to it:
 
 ```python
 def power(base: float, exponent: float) -> float:
@@ -28,77 +25,25 @@ def power(base: float, exponent: float) -> float:
     return base ** exponent
 ```
 
-Then, if the user's input utterance is "What is 2 to the power of 3?", the route will be triggered, as the input utterance is semantically similar to the route utterances. Furthermore, the route utilizes an LLM to identify that `base=2` and `exponent=3`. These values are returned in such a way that they can be used in the above `power` function. That is, the dynamic router automates the process of calling relevant functions from natural language inputs.
+Now ask "What is 2 to the power of 3?". The route matches on meaning, same as any route. Then an LLM reads the query and works out that `base=2` and `exponent=3`, in a shape you can pass straight to `power()`. That's the whole idea: natural language in, a ready-to-call function out.
 
-As with static routes, we must create a dynamic route before adding it to our router. To make a route dynamic, we need to provide the `function_schemas` as a list. Each function schema provides instructions on what a function is, so that an LLM can decide how to use it correctly.
+To make a route dynamic, give it `function_schemas` — a list describing each function so the LLM knows what it does and what it needs. The rest of this page walks through it.
 
-```python
-from datetime import datetime
-from zoneinfo import ZoneInfo
-
-
-def get_time(timezone: str) -> str:
-    """Finds the current time in a specific timezone.
-
-    :param timezone: The timezone to find the current time in, should
-        be a valid timezone from the IANA Time Zone Database like
-        "America/New_York" or "Europe/London". Do NOT put the place
-        name itself like "rome", or "new york", you must provide
-        the IANA format.
-    :type timezone: str
-    :return: The current time in the specified timezone."""
-    now = datetime.now(ZoneInfo(timezone))
-    return now.strftime("%H:%M")
-```
-
-```python
-get_time("America/New_York")
-```
-
-To get the function schema we can use the `get_schemas_openai` function.
-
-```python
-from semantic_router.llms.openai import get_schemas_openai
-
-schemas = get_schemas_openai([get_time])
-schemas
-```
-
-We use this to define our dynamic route:
-
-```python
-from semantic_router import Route
-
-time_route = Route(
-    name="get_time",
-    utterances=[
-        "what is the time in new york city?",
-        "what is the time in london?",
-        "I live in Rome, what time is it?",
-    ],
-    function_schemas=schemas,
-)
-```
-
-Then add the new route to a router.
-
-## Full Example
+## Full example
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/aurelio-labs/semantic-router/blob/main/docs/02-dynamic-routes.ipynb)
 [![Open nbviewer](https://raw.githubusercontent.com/pinecone-io/examples/master/assets/nbviewer-shield.svg)](https://nbviewer.org/github/aurelio-labs/semantic-router/blob/main/docs/02-dynamic-routes.ipynb)
-
-### Installing the Library
 
 ```python
 !pip install tzdata
 !pip install -qU semantic-router>=0.1.5
 ```
 
-### Initializing Routes and SemanticRouter
+> **Prefer to run this locally?** There's a fully local version of dynamic routes in [05-local-execution.ipynb](https://github.com/aurelio-labs/semantic-router/blob/main/docs/05-local-execution.ipynb). It tends to outperform the OpenAI version shown here, so it's worth a try.
 
-Dynamic routes are treated in the same way as static routes, let's begin by initializing a `SemanticRouter` consisting of static routes.
+### Start with static routes
 
-**⚠️ Note: We have a fully local version of dynamic routes available at [docs/05-local-execution.ipynb](https://github.com/aurelio-labs/semantic-router/blob/main/docs/05-local-execution.ipynb). The local version tends to outperform the OpenAI version we demo in this document, so we'd recommend trying [05-local-execution.ipynb](https://github.com/aurelio-labs/semantic-router/blob/main/docs/05-local-execution.ipynb)!**
+Dynamic routes sit alongside static ones, so let's build a router with two static routes first.
 
 ```python
 from semantic_router import Route
@@ -108,7 +53,8 @@ politics = Route(
     utterances=[
         "isn't politics the best thing ever",
         "why don't you tell me about your political opinions",
-        "don't you just love the president", "don't you just hate the president",
+        "don't you just love the president",
+        "don't you just hate the president",
         "they're going to destroy this country!",
         "they will save the country!",
     ],
@@ -127,11 +73,11 @@ chitchat = Route(
 routes = [politics, chitchat]
 ```
 
-We initialize our `SemanticRouter` with our `encoder` and `routes`. We can use popular encoder APIs like `CohereEncoder` and `OpenAIEncoder`, or local alternatives like `FastEmbedEncoder`.
+Pick an encoder. Any will do — `CohereEncoder`, `OpenAIEncoder`, or a local one like `FastEmbedEncoder`.
 
 ```python
 import os
-from semantic_router.routers import SemanticRouter
+from semantic_router import SemanticRouter
 from semantic_router.encoders import OpenAIEncoder
 
 # platform.openai.com
@@ -142,7 +88,7 @@ encoder = OpenAIEncoder()
 sr = SemanticRouter(encoder=encoder, routes=routes, auto_sync="local")
 ```
 
-We run the router with only static routes:
+Check it works with static routes only:
 
 ```python
 sr("how's the weather today?")
@@ -152,9 +98,9 @@ sr("how's the weather today?")
 RouteChoice(name='chitchat', function_call=None, similarity_score=None)
 ```
 
-### Creating a Dynamic Route
+### Add a dynamic route
 
-As with static routes, we must create a dynamic route before adding it to our router. To make a route dynamic, we need to provide the `function_schemas` as a list. Each function schema provides instructions on what a function is, so that an LLM can decide how to use it correctly.
+Here's the function we want the route to call — it returns the current time in a timezone. The docstring matters: the LLM reads it to learn what the `timezone` argument should look like.
 
 ```python
 from datetime import datetime
@@ -183,7 +129,7 @@ get_time("America/New_York")
 '17:57'
 ```
 
-To get the function schema we can use the `get_schemas_openai` function.
+Generate the schema from the function with `get_schemas_openai`:
 
 ```python
 from semantic_router.llms.openai import get_schemas_openai
@@ -192,7 +138,7 @@ schemas = get_schemas_openai([get_time])
 schemas
 ```
 
-We use this to define our dynamic route:
+Then define the route, passing the schema in:
 
 ```python
 time_route = Route(
@@ -206,13 +152,13 @@ time_route = Route(
 )
 ```
 
-Add the new route to our router:
+Add it to the router:
 
 ```python
 sr.add(time_route)
 ```
 
-Now we can ask our router a time related question to trigger our new dynamic route.
+Now ask a time question:
 
 ```python
 response = sr("what is the time in new york city?")
@@ -223,21 +169,12 @@ response
 RouteChoice(name='get_time', function_call=[{'function_name': 'get_time', 'arguments': {'timezone': 'America/New_York'}}], similarity_score=None)
 ```
 
-```python
-print(response.function_call)
-```
-
-```
-[{'function_name': 'get_time', 'arguments': {'timezone': 'America/New_York'}}]
-```
+The route matched *and* the LLM filled in the arguments. `function_call` holds everything you need to run it:
 
 ```python
-import json
-
 for call in response.function_call:
     if call["function_name"] == "get_time":
-        args = call["arguments"]
-        result = get_time(**args)
+        result = get_time(**call["arguments"])
 print(result)
 ```
 
@@ -245,20 +182,17 @@ print(result)
 17:57
 ```
 
-Our dynamic route provides both the route itself *and* the input parameters required to use the route.
+### One route, several functions
 
-### Dynamic Routes with Multiple Functions
+A route can carry more than one function. When it matches, the LLM decides which functions the query needs — and it can call several at once if the query asks for several things.
 
-Routes can be assigned multiple functions. Then, when that particular Route is selected by the Router, a number of those functions might be invoked due to the users utterance containing relevant information that fits their arguments.
-
-Let's define a Route that has multiple functions.
+Let's give one route three timezone tools:
 
 ```python
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 
-# Function with one argument
 def get_time(timezone: str) -> str:
     """Finds the current time in a specific timezone.
 
@@ -280,24 +214,19 @@ def get_time_difference(timezone1: str, timezone2: str) -> str:
     :type timezone1: str
     :type timezone2: str
     :return: The time difference in hours between the two timezones."""
-    # Get the current time in UTC
     now_utc = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
 
-    # Convert the UTC time to the specified timezones
     tz1_time = now_utc.astimezone(ZoneInfo(timezone1))
     tz2_time = now_utc.astimezone(ZoneInfo(timezone2))
 
-    # Calculate the difference in offsets from UTC
     tz1_offset = tz1_time.utcoffset().total_seconds()
     tz2_offset = tz2_time.utcoffset().total_seconds()
 
-    # Calculate the difference in hours
     hours_difference = (tz2_offset - tz1_offset) / 3600
 
     return f"The time difference between {timezone1} and {timezone2} is {hours_difference} hours."
 
 
-# Function with three arguments
 def convert_time(time: str, from_timezone: str, to_timezone: str) -> str:
     """Converts a specific time from one timezone to another.
     :param time: The time to convert in HH:MM format.
@@ -313,7 +242,7 @@ def convert_time(time: str, from_timezone: str, to_timezone: str) -> str:
         convert_time("12:30", "America/New_York", "Asia/Tokyo") -> "03:30"
     """
     try:
-        # Use today's date to avoid historical timezone issues
+        # use today's date to avoid historical timezone issues
         today = datetime.now().date()
         datetime_string = f"{today} {time}"
         time_obj = datetime.strptime(datetime_string, "%Y-%m-%d %H:%M").replace(
@@ -321,80 +250,65 @@ def convert_time(time: str, from_timezone: str, to_timezone: str) -> str:
         )
 
         converted_time = time_obj.astimezone(ZoneInfo(to_timezone))
-
-        formatted_time = converted_time.strftime("%H:%M")
-        return formatted_time
+        return converted_time.strftime("%H:%M")
     except Exception as e:
         raise ValueError(f"Error converting time: {e}")
 ```
 
-```python
-functions = [get_time, get_time_difference, convert_time]
-```
+Generate schemas for all three and build the route. Give it utterances that cover each function, plus a couple that hit several at once:
 
 ```python
-# Generate schemas for all functions
 from semantic_router.llms.openai import get_schemas_openai
 
+functions = [get_time, get_time_difference, convert_time]
 schemas = get_schemas_openai(functions)
-```
 
-```python
-# Define the dynamic route with multiple functions
 multi_function_route = Route(
     name="timezone_management",
     utterances=[
-        # Utterances for get_time function
+        # get_time
         "what is the time in New York?",
         "current time in Berlin?",
         "tell me the time in Moscow right now",
         "can you show me the current time in Tokyo?",
         "please provide the current time in London",
-        # Utterances for get_time_difference function
+        # get_time_difference
         "how many hours ahead is Tokyo from London?",
         "time difference between Sydney and Cairo",
         "what's the time gap between Los Angeles and New York?",
         "how much time difference is there between Paris and Sydney?",
         "calculate the time difference between Dubai and Toronto",
-        # Utterances for convert_time function
+        # convert_time
         "convert 15:00 from New York time to Berlin time",
         "change 09:00 from Paris time to Moscow time",
         "adjust 20:00 from Rome time to London time",
         "convert 12:00 from Madrid time to Chicago time",
-        "change 18:00 from Beijing time to Los Angeles time"
-        # All three functions
+        "change 18:00 from Beijing time to Los Angeles time",
+        # all three
         "What is the time in Seattle? What is the time difference between Mumbai and Tokyo? What is 5:53 Toronto time in Sydney time?",
     ],
     function_schemas=schemas,
 )
-```
 
-```python
 routes = [politics, chitchat, multi_function_route]
-```
-
-```python
 sr2 = SemanticRouter(encoder=encoder, routes=routes, auto_sync="local")
 ```
 
-#### Function to Parse Router Responses
+A small dispatcher runs whatever the router asks for:
 
 ```python
-def parse_response(response: str):
+def parse_response(response):
     for call in response.function_call:
         args = call["arguments"]
         if call["function_name"] == "get_time":
-            result = get_time(**args)
-            print(result)
+            print(get_time(**args))
         if call["function_name"] == "get_time_difference":
-            result = get_time_difference(**args)
-            print(result)
+            print(get_time_difference(**args))
         if call["function_name"] == "convert_time":
-            result = convert_time(**args)
-            print(result)
+            print(convert_time(**args))
 ```
 
-#### Testing the `multi_function_route` - Multiple Functions at Once
+Now ask for three things in one go:
 
 ```python
 response = sr2(
@@ -404,15 +318,14 @@ response = sr2(
     What is 5:53 Lisbon time in Bangkok time?
 """
 )
-```
-
-```python
 response
 ```
 
 ```
 RouteChoice(name='timezone_management', function_call=[{'function_name': 'get_time', 'arguments': {'timezone': 'Europe/Prague'}}, {'function_name': 'get_time_difference', 'arguments': {'timezone1': 'Europe/Berlin', 'timezone2': 'Asia/Shanghai'}}, {'function_name': 'convert_time', 'arguments': {'time': '05:53', 'from_timezone': 'Europe/Lisbon', 'to_timezone': 'Asia/Bangkok'}}], similarity_score=None)
 ```
+
+All three functions, each with the right arguments. Run them:
 
 ```python
 parse_response(response)
@@ -422,4 +335,4 @@ parse_response(response)
 23:58
 The time difference between Europe/Berlin and Asia/Shanghai is 6.0 hours.
 11:53
-``` 
+```

--- a/docs/user-guide/features/route-filter.md
+++ b/docs/user-guide/features/route-filter.md
@@ -1,25 +1,23 @@
-We can filter the routes that the `SemanticRouter` considers when making a classification. This can be useful if we want to restrict the scope of possible routes based on some context.
+Sometimes you only want the router to consider *some* of its routes. Maybe context tells you the user is mid-conversation about one topic, or a certain route shouldn't fire in this part of your app. `route_filter` lets you narrow the field per call.
 
-For example, we may have a router with several routes, `politics`, `weather`, `chitchat`, etc. We may want to restrict the scope of the classification to only consider the `chitchat` route. We can do this by passing a `route_filter` argument to our `SemanticRouter` calls like so:
+Say your router has `politics`, `weather`, and `chitchat`. To consider only `chitchat` for one query:
 
 ```python
 sr("don't you love politics?", route_filter=["chitchat"])
 ```
 
-In this case, the `SemanticRouter` will only consider the `chitchat` route for the classification.
+The router ignores every route not in the list.
 
-## Full Example
+## Full example
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/aurelio-labs/semantic-router/blob/main/docs/09-route-filter.ipynb)
-[![Open nbviewer](https://raw.githubusercontent.com/pinecone-io/examples/master/assets/nbviewer-shield.svg)](https://nbviewer.org/github/aurelio-labs/semantic-router/blob/main/docs/00-introduction.ipynb)
-
-We start by installing the library:
+[![Open nbviewer](https://raw.githubusercontent.com/pinecone-io/examples/master/assets/nbviewer-shield.svg)](https://nbviewer.org/github/aurelio-labs/semantic-router/blob/main/docs/09-route-filter.ipynb)
 
 ```python
 !pip install -qU semantic-router
 ```
 
-We start by defining a dictionary mapping routes to example phrases that should trigger those routes.
+Two routes to work with:
 
 ```python
 from semantic_router import Route
@@ -35,11 +33,7 @@ politics = Route(
         "they will save the country!",
     ],
 )
-```
 
-Let's define another for good measure:
-
-```python
 chitchat = Route(
     name="chitchat",
     utterances=[
@@ -54,7 +48,7 @@ chitchat = Route(
 routes = [politics, chitchat]
 ```
 
-Now we initialize our embedding model:
+An encoder:
 
 ```python
 import os
@@ -72,15 +66,15 @@ encoder = CohereEncoder()
 # encoder = OpenAIEncoder()
 ```
 
-Now we define the `SemanticRouter`. When called, the router will consume text (a query) and output the category (`Route`) it belongs to — to initialize a `SemanticRouter` we need our `encoder` model and a list of `routes`.
+And the router:
 
 ```python
-from semantic_router.routers import SemanticRouter
+from semantic_router import SemanticRouter
 
 sr = SemanticRouter(encoder=encoder, routes=routes)
 ```
 
-Now we can test it:
+Without a filter it behaves as usual:
 
 ```python
 sr("don't you love politics?")
@@ -98,7 +92,7 @@ sr("how's the weather today?")
 RouteChoice(name='chitchat', function_call=None, similarity_score=None)
 ```
 
-Both are classified accurately, what if we send a query that is unrelated to our existing `Route` objects?
+And an unrelated query returns `None`:
 
 ```python
 sr("I'm interested in learning about llama 2")
@@ -108,13 +102,9 @@ sr("I'm interested in learning about llama 2")
 RouteChoice(name=None, function_call=None, similarity_score=None)
 ```
 
-In this case, we return `None` because no matches were identified.
+## Filtering
 
-## Demonstrating the Filter Feature
-
-Now, let's demonstrate the filter feature. We can specify a subset of routes to consider when making a classification. This can be useful if we want to restrict the scope of possible routes based on some context.
-
-For example, let's say we only want to consider the "chitchat" route for a particular query:
+Now restrict the router to `chitchat` and send it a political query:
 
 ```python
 sr("don't you love politics?", route_filter=["chitchat"])
@@ -124,9 +114,9 @@ sr("don't you love politics?", route_filter=["chitchat"])
 RouteChoice(name='chitchat', function_call=None, similarity_score=None)
 ```
 
-Even though the query might be more related to the "politics" route, it will be classified as "chitchat" because we've restricted the routes to consider.
+It comes back as `chitchat` — the query would normally match `politics`, but that route wasn't allowed, and `chitchat` still cleared its threshold.
 
-Similarly, we can restrict it to the "politics" route:
+The other way round:
 
 ```python
 sr("how's the weather today?", route_filter=["politics"])
@@ -136,4 +126,4 @@ sr("how's the weather today?", route_filter=["politics"])
 RouteChoice(name=None, function_call=None, similarity_score=None)
 ```
 
-In this case, it will return `None` because the query doesn't match the "politics" route well enough to pass the threshold. 
+`None` this time. The weather query is nowhere near `politics`, so nothing passed the threshold. A filter narrows the candidates; it doesn't force a match.

--- a/docs/user-guide/features/sync.md
+++ b/docs/user-guide/features/sync.md
@@ -1,37 +1,31 @@
-The `SemanticRouter` class is the main class in the semantic router package. It contains the routes and allows us to interact with the underlying index. Both the `SemanticRouter` and the various index classes support synchronization strategies that allow us to synchronize the routes and utterances in the layer with the underlying index.
+When you use a remote index like `PineconeIndex` or `QdrantIndex`, there are two copies of your routes: the ones in your `SemanticRouter` object, and the ones stored in the index. They can drift. Sync strategies decide which copy wins when they do.
 
-This functionality becomes increasingly important when using the semantic router in a distributed environment. For example, when using one of the *remote instances*, such as `PineconeIndex` or `QdrantIndex`. Deciding the correct synchronization strategy for these remote indexes will save application time and reduce the risk of errors.
+Getting this right matters most in distributed setups, where several processes share one index. Pick the right strategy and you avoid both wasted startup time and subtle routing bugs.
 
-Semantic router supports several synchronization strategies. Those strategies are:
+## The strategies
 
-* `error`: Raise an error if local and remote are not synchronized.
+- **`error`** — raise if local and remote differ. Use this when drift should never happen silently.
+- **`remote`** — remote is the source of truth. Overwrite local to match.
+- **`local`** — local is the source of truth. Overwrite remote to match.
+- **`merge-force-local`** — merge, with local winning. Remote utterances survive only if their route also exists locally; everything else is dropped. Where a route exists on both sides with different `function_schemas` or `metadata`, local's version wins and is written to remote.
+- **`merge-force-remote`** — the mirror image. Remote wins; local utterances survive only if their route exists remotely.
+- **`merge`** — merge both, combining utterances where a route name appears on both sides. On a conflict in `function_schemas` or `metadata`, local wins.
 
-* `remote`: Take remote as the source of truth and update local to align.
+You can apply a strategy two ways: automatically at startup with `auto_sync`, or on demand with `SemanticRouter.sync`.
 
-* `local`: Take local as the source of truth and update remote to align.
+## `auto_sync` at startup
 
-* `merge-force-local`: Merge both local and remote keeping local as the priority. Remote utterances are only merged into local *if* a matching route for the utterance is found in local, all other route-utterances are dropped. Where a route exists in both local and remote, but each contains different `function_schema` or `metadata` information, the local version takes priority and local `function_schemas` and `metadata` is propagated to all remote utterances belonging to the given route.
-
-* `merge-force-remote`: Merge both local and remote keeping remote as the priority. Local utterances are only merged into remote *if* a matching route for the utterance is found in the remote, all other route-utterances are dropped. Where a route exists in both local and remote, but each contains different `function_schema` or `metadata` information, the remote version takes priority and remote `function_schemas` and `metadata` are propagated to all local routes.
-
-* `merge`: Merge both local and remote, merging also local and remote utterances when a route with same route name is present both locally and remotely. If a route exists in both local and remote but contains different `function_schemas` or `metadata` information, the local version takes priority and local `function_schemas` and `metadata` are propagated to all remote routes.
-
-There are two ways to specify the synchronization strategy. The first is to specify the strategy when initializing the `SemanticRouter` object via the `auto_sync` parameter. The second is to trigger synchronization directly via the `SemanticRouter.sync` method.
-
----
-
-## Using the `auto_sync` parameter
-
-The `auto_sync` parameter is used to specify the synchronization strategy when initializing the `SemanticRouter` object. Depending on the chosen strategy, the `SemanticRouter` object will automatically synchronize with the defined index. As this happens on initialization, this will often increase the initialization time of the `SemanticRouter` object.
-
-Let's see an example of `auto_sync` in action.
+Pass `auto_sync` when you create the router, and it reconciles with the index immediately. Note this adds to initialization time, since it has to compare and possibly write.
 
 ```python
+import os
 from semantic_router import Route, SemanticRouter
 from semantic_router.encoders import OpenAIEncoder
-from semantic_router.indexes import PineconeIndex
+from semantic_router.index import PineconeIndex
 
-# we could use this as a guide for our chatbot to avoid political conversations
+os.environ["OPENAI_API_KEY"] = "<YOUR_API_KEY>"
+os.environ["PINECONE_API_KEY"] = "<YOUR_API_KEY>"
+
 politics = Route(
     name="politics",
     utterances=[
@@ -44,8 +38,6 @@ politics = Route(
     ],
 )
 
-# this could be used as an indicator to our chatbot to switch to a more
-# conversational prompt
 chitchat = Route(
     name="chitchat",
     utterances=[
@@ -57,63 +49,48 @@ chitchat = Route(
     ],
 )
 
-# we place both of our decisions together into single list
 routes = [politics, chitchat]
 
-encoder = OpenAIEncoder(openai_api_key=openai_api_key)
+encoder = OpenAIEncoder()
 
 pc_index = PineconeIndex(
-    api_key=pinecone_api_key,
     region="us-east-1",
     index_name="sync-example",
 )
-# before initializing the SemanticRouter with auto_sync we should initialize
-# the index
+# make sure the index exists before the router tries to sync with it
 pc_index.index = pc_index._init_index(force_create=True)
 
-# now we can initialize the SemanticRouter with local auto_sync
 sr = SemanticRouter(
     encoder=encoder, routes=routes, index=pc_index,
-    auto_sync="local"
+    auto_sync="local",
 )
 ```
 
-Now we can run `sr.is_synced()` to confirm that our local and remote instances are synchronized.
+Confirm the two sides agree:
 
 ```python
 sr.is_synced()
 ```
 
-## Checking for Synchronization
+## Checking sync
 
-To verify whether the local and remote instances are synchronized, you can use the `SemanticRouter.is_synced` method. This method checks if the routes, utterances, and associated metadata in the local instance match those stored in the remote index.
+`is_synced()` compares the routes, utterances, and metadata in your router against what's in the index. It works in two passes.
 
-The `is_synced` method works in two steps. The first is our *fast* sync check. The fast check creates a hash of our local route layer which is constructed from:
+**The fast check** hashes your local router — built from the encoder type and name, plus each route's name, utterances, description, function schemas, LLM, score threshold, and metadata — and compares it to the hash stored in the index. Matching hashes mean you're in sync, and it returns `True` straight away.
 
-- `encoder_type` and `encoder_name`
-- `route` names
-- `route` utterances
-- `route` description
-- `route` function schemas (if any)
-- `route` llm (if any)
-- `route` score threshold
-- `route` metadata (if any)
+**The slow check** only runs if the hashes differ. It rebuilds a `LayerConfig` from the remote index and compares it to the local one field by field. If those match, you're in sync after all. If not, something has genuinely drifted.
 
-The fast check then compares this hash to the hash of the remote index. If the hashes match, we know that the local and remote instances are synchronized and we can return `True`. If the hashes do not match, we need to perform a *slow* sync check.
-
-The slow sync check works by creating a `LayerConfig` object from the remote index and then comparing this to our local `LayerConfig` object. If the two objects match, we know that the local and remote instances are synchronized and we can return `True`. If the two objects do not match, we must investigate and decide how to synchronize the two instances.
-
-To quickly sync the local and remote instances we can use the `SemanticRouter.sync` method. This method is equivalent to the `auto_sync` strategy specified when initializing the `SemanticRouter` object. So, if we assume our local `SemanticRouter` object contains the ground truth routes, we would use the `local` strategy to copy our local routes to the remote instance.
+To fix drift on demand, call `sync` with a strategy. It does exactly what `auto_sync` would do at startup. If your local router holds the ground truth, push it to the index:
 
 ```python
 sr.sync(sync_mode="local")
 ```
 
-After running the above code, we can check whether the local and remote instances are synchronized by rerunning `sr.is_synced()`, which should now return `True`.
+Run `sr.is_synced()` again and it should now return `True`.
 
-## Investigating Synchronization Differences
+## Seeing what drifted
 
-We may often need to further investigate and understand *why* our local and remote instances have become desynchronized. The first step in further investigation and resolution of synchronization differences is to see the differences. We can get a readable diff using the `SemanticRouter.get_utterance_diff` method.
+Often you'll want to know *why* things diverged before you overwrite anything. `get_utterance_diff` gives you a readable diff:
 
 ```python
 diff = sr.get_utterance_diff()
@@ -133,72 +110,43 @@ diff = sr.get_utterance_diff()
 '+ chitchat: let\'s go to the chippy']
 ```
 
-The diff works by creating a list of all the routes in the remote index and then comparing these to the routes in our local instance. Any differences between the remote and local routes are shown in the above diff.
+It lists every route in the remote index and compares it against your local routes. Anything that differs shows up here.
 
-Now, to resolve these differences we will need to initialize an `UtteranceDiff` object. This object will contain the differences between the remote and local utterances. We can then use this object to decide how to synchronize the two instances. To initialize the `UtteranceDiff` object we need to get our local and remote utterances.
+For finer control, build an `UtteranceDiff` object from the two sets of utterances:
 
 ```python
 local_utterances = sr.to_config().to_utterances()
 remote_utterances = sr.index.get_utterances()
-```
 
-We create an utterance diff object like so:
-
-```python
 diff = UtteranceDiff.from_utterances(
     local_utterances=local_utterances, remote_utterances=remote_utterances
 )
 ```
 
-`UtteranceDiff` objects include all diff information inside the `diff` attribute (which is a list of `Utterance` objects). Each of our `Utterance` objects inside `UtteranceDiff.diff` now contain a populated `diff_tag` attribute, where:
+Every `Utterance` in `diff.diff` carries a `diff_tag`:
 
-- `diff_tag='+'` indicates the utterance exists in the remote instance *only*.
-- `diff_tag='-'` indicates the utterance exists in the local instance *only*.
-- `diff_tag=' '` indicates the utterance exists in both the local and remote instances.
+- `'+'` — exists in remote only.
+- `'-'` — exists in local only.
+- `' '` — exists in both.
 
-After initializing an `UtteranceDiff` object we can get all utterances with each diff tag like so:
+Pull out whichever set you want to inspect:
 
 ```python
-# all utterances that exist only in remote
-diff.get_tag("+")
-
-# all utterances that exist only in local
-diff.get_tag("-")
-
-# all utterances that exist in both local and remote
-diff.get_tag(" ")
+diff.get_tag("+")  # remote only
+diff.get_tag("-")  # local only
+diff.get_tag(" ")  # both
 ```
 
-These can be investigated if needed. Once we're happy with our understanding of the issues we can resolve them by executing a synchronization by running the `SemanticRouter._execute_sync_strategy` method:
+Once you understand the drift and know which side should win, apply a strategy:
 
 ```python
 sr._execute_sync_strategy(sync_mode="local")
 ```
 
-Once complete, we can confirm that our local and remote instances are synchronized by running `sr.is_synced()`:
+Then confirm:
 
 ```python
 sr.is_synced()
 ```
 
-If the above returns `True` we are now synchronized!
-
-```
-                  .=                
-                 :%%*               
-                -%%%%#              
-               =%%%%%%#.            
-              +%%%%%%%+             
-             *%%%%%%%=              
-           .#%%%%%%%-               
-          .#%%%%%%%: -%:            
-         :%%%%%%%#. =%%%=           
-        -%%%%%%%#  *%%%%%+          
-       =%%%%%%%*  -%%%%%%%*         
-      .-------:    -%%%%%%%#        
-:*****************+ :%%%%%%%#.      
--%%%%%%%%%%%%%%%%%%%* .#%%%%%%%:     
-=%%%%%%%%%%%%%%%%%%%%%#..#%%%%%%%-    
-+%%%%%%%%%%%%%%%%%%%%%%%#. *%%%%%%%=   
-                         +%%%%%%%+  
-                          =#######+ 
+`True` means the two sides match again.

--- a/docs/user-guide/features/threshold-optimization.md
+++ b/docs/user-guide/features/threshold-optimization.md
@@ -1,8 +1,8 @@
-Route score thresholds are what defines whether a route should be chosen. If the score we identify for any given route is higher than the `Route.score_threshold` it passes, otherwise it does not and *either* another route is chosen, or we return *no* route.
+A route matches only if its similarity score beats its `score_threshold`. Score above it and the route is chosen. Fall below and either another route wins, or nothing does.
 
-Given that this one `score_threshold` parameter can define the choice of a route, it's important to get it right — but it's incredibly inefficient to do so manually. Instead, we can use the `fit` and `evaluate` methods of our `SemanticRouter`. All we must do is pass a smaller number of *(utterance, target route)* examples to our methods, and with `fit` we will often see dramatically improved performance within seconds.
+That one number decides a lot, so it's worth getting right — but tuning it by hand is slow and fiddly. Instead, hand the router a few *(utterance, target route)* examples and let `fit` find the thresholds for you. It usually takes seconds and the improvement can be dramatic. `evaluate` tells you how well you're doing before and after.
 
-## Full Example
+## Full example
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/aurelio-labs/semantic-router/blob/main/docs/06-threshold-optimization.ipynb) [![Open nbviewer](https://raw.githubusercontent.com/pinecone-io/examples/master/assets/nbviewer-shield.svg)](https://nbviewer.org/github/aurelio-labs/semantic-router/blob/main/docs/06-threshold-optimization)
 
@@ -10,29 +10,29 @@ Given that this one `score_threshold` parameter can define the choice of a route
 !pip install -qU "semantic-router>=0.1.5"
 ```
 
-## Define SemanticRouter
+## Set up the router
 
-As usual we will define our `SemanticRouter`. The `SemanticRouter` requires just `routes` and an `encoder`. If using dynamic routes you must also define an `llm` (or use the OpenAI default).
+A `SemanticRouter` needs `routes` and an `encoder`. (If you use dynamic routes you'll also want an `llm`, or the OpenAI default.)
 
-We will start by defining four routes; *politics*, *chitchat*, *mathematics*, and *biology*.
+Four routes to start: *politics*, *chitchat*, *mathematics*, and *biology*.
 
 ```python
 from semantic_router import Route
 
-# we could use this as a guide for our chatbot to avoid political conversations
+# steer a chatbot away from politics
 politics = Route(
     name="politics",
     utterances=[
         "isn't politics the best thing ever",
         "why don't you tell me about your political opinions",
-        "don't you just love the president" "don't you just hate the president",
+        "don't you just love the president",
+        "don't you just hate the president",
         "they're going to destroy this country!",
         "they will save the country!",
     ],
 )
 
-# this could be used as an indicator to our chatbot to switch to a more
-# conversational prompt
+# switch to a more conversational prompt
 chitchat = Route(
     name="chitchat",
     utterances=[
@@ -44,7 +44,7 @@ chitchat = Route(
     ],
 )
 
-# we can use this to switch to an agent with more math tools, prompting, and LLMs
+# hand off to an agent with math tools
 mathematics = Route(
     name="mathematics",
     utterances=[
@@ -56,7 +56,7 @@ mathematics = Route(
     ],
 )
 
-# we can use this to switch to an agent with more biology knowledge
+# hand off to an agent with biology knowledge
 biology = Route(
     name="biology",
     utterances=[
@@ -68,11 +68,10 @@ biology = Route(
     ],
 )
 
-# we place all of our decisions together into single list
 routes = [politics, chitchat, mathematics, biology]
 ```
 
-For our encoder we will use the local `HuggingFaceEncoder`. Other popular encoders include `CohereEncoder`, `FastEmbedEncoder`, `OpenAIEncoder`, and `AzureOpenAIEncoder`.
+We'll use the local `HuggingFaceEncoder`. `CohereEncoder`, `FastEmbedEncoder`, `OpenAIEncoder`, and `AzureOpenAIEncoder` all work too.
 
 ```python
 from semantic_router.encoders import HuggingFaceEncoder
@@ -80,15 +79,13 @@ from semantic_router.encoders import HuggingFaceEncoder
 encoder = HuggingFaceEncoder()
 ```
 
-Now we initialize our `SemanticRouter`.
-
 ```python
 from semantic_router import SemanticRouter
 
 sr = SemanticRouter(encoder=encoder, routes=routes)
 ```
 
-By default, we should get reasonable performance:
+Out of the box it does reasonably well:
 
 ```python
 for utterance in [
@@ -107,7 +104,9 @@ What's DNA? -> biology
 I'm interested in learning about llama 2 -> None
 ```
 
-We can evaluate the performance of our route layer using the `evaluate` method. All we need is to pass a list of utterances and target route labels:
+## Measure it
+
+`evaluate` takes a list of utterances and their target routes and returns an accuracy:
 
 ```python
 test_data = [
@@ -117,10 +116,8 @@ test_data = [
     ("I'm interested in learning about llama 2", None),
 ]
 
-# unpack the test data
 X, y = zip(*test_data)
 
-# evaluate using the default thresholds
 accuracy = sr.evaluate(X=X, y=y)
 print(f"Accuracy: {accuracy*100:.2f}%")
 ```
@@ -130,9 +127,9 @@ Generating embeddings: 100%|██████████| 1/1 [00:00<00:00, 76
 Accuracy: 100.00%
 ```
 
-On this small subset we get perfect accuracy — but what if we try with a larger, more robust dataset?
+Perfect — on four examples. That's not a real test. Let's try a bigger, harder set.
 
-*Hint: try using GPT-4 or another LLM to generate some examples for your own use-cases. The more accurate examples you provide, the better you can expect the routes to perform on your actual use-case.*
+*Tip: an LLM is a quick way to generate test examples for your own routes. The more realistic they are, the more your accuracy number will reflect real-world performance.*
 
 ```python
 test_data = [
@@ -199,7 +196,7 @@ test_data = [
     ("What is homeostasis?", "biology"),
     ("What is the difference between a virus and a bacteria?", "biology"),
     ("What is the role of the immune system?", "biology"),
-    # add some None routes to prevent excessively small thresholds
+    # some None examples, so thresholds don't collapse to zero
     ("What is the capital of France?", None),
     ("how many people live in the US?", None),
     ("when is the best time to visit Bali?", None),
@@ -211,10 +208,8 @@ test_data = [
 ```
 
 ```python
-# unpack the test data
 X, y = zip(*test_data)
 
-# evaluate using the default thresholds
 accuracy = sr.evaluate(X=X, y=y)
 print(f"Accuracy: {accuracy*100:.2f}%")
 ```
@@ -224,11 +219,11 @@ Generating embeddings: 100%|██████████| 1/1 [00:00<00:00, 9.
 Accuracy: 34.85%
 ```
 
-Ouch, that's not so good! Fortunately, we can easily improve our performance here.
+Ouch. The good news: this is easy to fix.
 
-## Router Optimization
+## Optimize the thresholds
 
-Our optimization works by finding the best route thresholds for each `Route` in our `SemanticRouter`. We can see the current, default thresholds by calling the `get_thresholds` method:
+Optimization finds the best `score_threshold` for each route. First, look at the defaults:
 
 ```python
 route_thresholds = sr.get_thresholds()
@@ -239,10 +234,9 @@ print("Default route thresholds:", route_thresholds)
 Default route thresholds: {'politics': 0.5, 'chitchat': 0.5, 'mathematics': 0.5, 'biology': 0.5}
 ```
 
-These are all preset route threshold values. Fortunately, it's very easy to optimize these — we simply call the `fit` method and provide our training utterances `X`, and target route labels `y`:
+Every route sits at 0.5. Now call `fit` with your training utterances `X` and labels `y`:
 
 ```python
-# Call the fit method
 sr.fit(X=X, y=y)
 ```
 
@@ -251,7 +245,7 @@ Generating embeddings: 100%|██████████| 1/1 [00:00<00:00, 9.
 Training: 100%|██████████| 500/500 [00:01<00:00, 419.45it/s, acc=0.89]
 ```
 
-Let's see what our new thresholds look like:
+The thresholds have moved a lot:
 
 ```python
 route_thresholds = sr.get_thresholds()
@@ -262,9 +256,9 @@ print("Updated route thresholds:", route_thresholds)
 Updated route thresholds: {'politics': 0.05050505050505051, 'chitchat': 0.32323232323232326, 'mathematics': 0.18181818181818182, 'biology': 0.21212121212121213}
 ```
 
-These are vastly different thresholds to what we were seeing before — it's worth noting that *optimal* values for different encoders can vary greatly. For example, OpenAI's Ada 002 model, when used with our encoders will tend to output much larger numbers in the `0.5` to `0.8` range.
+Don't read too much into the absolute values. The right thresholds depend heavily on the encoder — OpenAI's `text-embedding-ada-002`, for instance, tends to land in the `0.5` to `0.8` range with this library. That's exactly why fitting beats guessing.
 
-After training we have a final performance of:
+The result:
 
 ```python
 accuracy = sr.evaluate(X=X, y=y)
@@ -276,4 +270,6 @@ Generating embeddings: 100%|██████████| 1/1 [00:00<00:00, 8.
 Accuracy: 89.39%
 ```
 
-That is *much* better. If we wanted to optimize this further we can focus on adding more utterances to our existing routes, analyzing *where* exactly our failures are, and modifying our routes around those. This extended optimization process is much more manual, but with it we can continue optimizing routes to get even better performance. 
+From 35% to 89%, in about a second.
+
+To push further, the next lever is your routes themselves: add more utterances, look at *which* examples still fail, and reshape the routes around them. That's more hands-on than `fit`, but it's how you squeeze out the last few points.

--- a/docs/user-guide/guides/configuration.md
+++ b/docs/user-guide/guides/configuration.md
@@ -1,48 +1,43 @@
 # Configuration
 
-This guide covers various configuration options available in semantic-router.
+## Logging
 
-## Logging Configuration
+Semantic Router uses Python's standard `logging` module. You control how much it says with an environment variable.
 
-Semantic-router uses Python's logging module for debugging and monitoring. You can control the verbosity of logs using environment variables.
+### Setting the log level
 
-### Setting Log Levels
+Two variables work. Set the library-specific one if you can:
 
-You can configure the log level in two ways:
+```bash
+export SEMANTIC_ROUTER_LOG_LEVEL=DEBUG
+```
 
-1. **Using the semantic-router specific variable (recommended):**
-   ```bash
-   export SEMANTIC_ROUTER_LOG_LEVEL=DEBUG
-   ```
+Or use the general one, which other libraries may share:
 
-2. **Using the general LOG_LEVEL variable:**
-   ```bash
-   export LOG_LEVEL=WARNING
-   ```
+```bash
+export LOG_LEVEL=WARNING
+```
 
-The library checks for `SEMANTIC_ROUTER_LOG_LEVEL` first, then falls back to `LOG_LEVEL`. If neither is set, it defaults to `INFO`.
+`SEMANTIC_ROUTER_LOG_LEVEL` wins if both are set. If neither is, the level is `INFO`.
 
-### Available Log Levels
+### Levels
 
-- `DEBUG`: Detailed information for diagnosing problems
-- `INFO`: General informational messages (default)
-- `WARNING`: Warning messages for potentially problematic situations
-- `ERROR`: Error messages for serious problems
-- `CRITICAL`: Critical messages for very serious errors
+- `DEBUG` — detailed diagnostics.
+- `INFO` — general progress (the default).
+- `WARNING` — something looks off but still works.
+- `ERROR` — something failed.
+- `CRITICAL` — something failed badly.
 
-### Example Usage
+### From Python
+
+Set the variable *before* importing the library:
 
 ```python
 import os
-# Set before importing semantic-router
 os.environ["SEMANTIC_ROUTER_LOG_LEVEL"] = "DEBUG"
 
 from semantic_router import Route, SemanticRouter
-# Your debug logs will now be visible
+# debug logs now show
 ```
 
-This is particularly useful when:
-- Debugging encoder or index issues
-- Monitoring route matching decisions
-- Troubleshooting performance problems
-- Understanding the library's internal behavior
+Turn on `DEBUG` when you're chasing an encoder or index problem, want to see why a query matched the route it did, or need to understand what the library is doing under the hood.

--- a/docs/user-guide/guides/local-execution.md
+++ b/docs/user-guide/guides/local-execution.md
@@ -1,40 +1,40 @@
-There are many reasons users might choose to roll their own LLMs rather than use a third-party service. Whether it's due to cost, privacy or compliance, Semantic Router supports the use of "local" LLMs through `llama.cpp`.
+Plenty of reasons to run your own LLM instead of calling an API — cost, privacy, compliance. Semantic Router supports local LLMs through `llama.cpp`.
 
-Using `llama.cpp` also enables the use of quantized GGUF models, reducing the memory footprint of deployed models, allowing even 13-billion parameter models to run with hardware acceleration on an Apple M1 Pro chip.
+`llama.cpp` also runs quantized GGUF models, which shrink memory use enough that even a 13B-parameter model runs with hardware acceleration on an Apple M1 Pro.
 
-## Full Example
+## Full example
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/aurelio-labs/semantic-router/blob/main/docs/05-local-execution.ipynb)
 [![Open nbviewer](https://raw.githubusercontent.com/pinecone-io/examples/master/assets/nbviewer-shield.svg)](https://nbviewer.org/github/aurelio-labs/semantic-router/blob/main/docs/05-local-execution.ipynb)
 
-Below is an example of using semantic router with **Mistral-7B-Instruct**, quantized to reduce memory footprint.
+We'll use **Mistral-7B-Instruct**, quantized to 4-bit to keep the memory footprint small.
 
-## Installing the library
+## Install
 
-> Note: if you require hardware acceleration via BLAS, CUDA, Metal, etc. please refer to the [abetlen/llama-cpp-python](https://github.com/abetlen/llama-cpp-python#installation-with-specific-hardware-acceleration-blas-cuda-metal-etc) repository README.md
+> For hardware acceleration (BLAS, CUDA, Metal, and so on), see the [llama-cpp-python README](https://github.com/abetlen/llama-cpp-python#installation-with-specific-hardware-acceleration-blas-cuda-metal-etc).
 
 ```python
 pip install -qU "semantic-router[local]"
 ```
 
-If you're running on Apple silicon you can run the following to compile with Metal hardware acceleration:
+On Apple silicon, compile with Metal acceleration:
 
 ```bash
 CMAKE_ARGS="-DLLAMA_METAL=on" pip install -qU "semantic-router[local]"
 ```
 
-## Download the Mistral 7B Instruct 4-bit GGUF files
+## Download the model
 
-We will be using Mistral 7B Instruct, quantized as a 4-bit GGUF file, a good balance between performance and ability to deploy on consumer hardware
+Mistral 7B Instruct as a 4-bit GGUF is a good balance of quality and consumer-hardware friendliness:
 
 ```python
 !curl -L "https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/resolve/main/mistral-7b-instruct-v0.2.Q4_0.gguf?download=true" -o ./mistral-7b-instruct-v0.2.Q4_0.gguf
 !ls mistral-7b-instruct-v0.2.Q4_0.gguf
 ```
 
-## Initializing Dynamic Routes
+## Define the routes
 
-Similar to dynamic routes in other examples, we will be initializing some dynamic routes that make use of LLMs for function calling
+We'll include a dynamic route so the local LLM has some function calling to do:
 
 ```python
 from datetime import datetime
@@ -74,7 +74,8 @@ politics = Route(
     utterances=[
         "isn't politics the best thing ever",
         "why don't you tell me about your political opinions",
-        "don't you just love the president" "don't you just hate the president",
+        "don't you just love the president",
+        "don't you just hate the president",
         "they're going to destroy this country!",
         "they will save the country!",
     ],
@@ -93,9 +94,9 @@ chitchat = Route(
 routes = [politics, chitchat, time]
 ```
 
-## Encoders
+## Encoder
 
-You can use alternative Encoders, however, in this example we want to showcase a fully-local Semantic Router execution, so we are going to use a `HuggingFaceEncoder` with `sentence-transformers/all-MiniLM-L6-v2` (the default) as an embedding model.
+To stay fully local we'll use `HuggingFaceEncoder`, which defaults to `sentence-transformers/all-MiniLM-L6-v2`:
 
 ```python
 from semantic_router.encoders import HuggingFaceEncoder
@@ -103,26 +104,23 @@ from semantic_router.encoders import HuggingFaceEncoder
 encoder = HuggingFaceEncoder()
 ```
 
-## `llama.cpp` LLM
+## The `llama.cpp` LLM
 
-From here, we can go ahead and instantiate our `llama-cpp-python` `llama_cpp.Llama` LLM, and then pass it to the `semantic_router.llms.LlamaCppLLM` wrapper class.
+Create a `llama_cpp.Llama` and wrap it in `LlamaCppLLM`. Three parameters worth knowing:
 
-For `llama_cpp.Llama`, there are a couple of parameters you should pay attention to:
+- `n_gpu_layers` — how many layers to offload to the GPU. `-1` for the whole model, `0` for CPU only.
+- `n_ctx` — the context window. Capped by the model's own limit (8000 tokens for Mistral-7B-Instruct).
+- `verbose` — set `False` to quiet `llama.cpp`'s output.
 
-- `n_gpu_layers`: how many LLM layers to offload to the GPU (if you want to offload the entire model, pass `-1`, and for CPU execution, pass `0`)
-- `n_ctx`: context size, limit the number of tokens that can be passed to the LLM (this is bounded by the model's internal maximum context size, in this case for Mistral-7B-Instruct, 8000 tokens)
-- `verbose`: if `False`, silences output from `llama.cpp`
-
-> For other parameter explanation, refer to the `llama-cpp-python` [API Reference](https://llama-cpp-python.readthedocs.io/en/latest/api-reference/)
+> The [llama-cpp-python API reference](https://llama-cpp-python.readthedocs.io/en/latest/api-reference/) covers the rest.
 
 ```python
-# In semantic-router v0.1.0, RouteLayer has been replaced with SemanticRouter
 from semantic_router import SemanticRouter
 
 from llama_cpp import Llama
 from semantic_router.llms.llamacpp import LlamaCppLLM
 
-enable_gpu = True  # offload LLM layers to the GPU (must fit in memory)
+enable_gpu = True  # offload to GPU (the model must fit in memory)
 
 _llm = Llama(
     model_path="./mistral-7b-instruct-v0.2.Q4_0.gguf",
@@ -132,22 +130,22 @@ _llm = Llama(
 _llm.verbose = False
 llm = LlamaCppLLM(name="Mistral-7B-v0.2-Instruct", llm=_llm, max_tokens=None)
 
-# Initialize SemanticRouter with our encoder, routes, and LLM
 router = SemanticRouter(encoder=encoder, routes=routes, llm=llm)
 ```
 
-Let's test our router with some queries:
+## Try it
+
+A static route first:
 
 ```python
 router("how's the weather today?")
 ```
 
-This should output:
 ```
 RouteChoice(name='chitchat', function_call=None, similarity_score=None)
 ```
 
-Now let's try a time-related query that will trigger our function calling:
+Now a time question, which triggers the dynamic route and the local LLM:
 
 ```python
 out = router("what's the time in New York right now?")
@@ -155,13 +153,12 @@ print(out)
 get_time(**out.function_call[0])
 ```
 
-This should output something like:
 ```
 name='get_time' function_call=[{'timezone': 'America/New_York'}] similarity_score=None
 '07:50'
 ```
 
-Let's try more examples:
+A couple more:
 
 ```python
 out = router("what's the time in Rome right now?")
@@ -169,7 +166,6 @@ print(out)
 get_time(**out.function_call[0])
 ```
 
-Output:
 ```
 name='get_time' function_call=[{'timezone': 'Europe/Rome'}] similarity_score=None
 '13:51'
@@ -181,16 +177,17 @@ print(out)
 get_time(**out.function_call[0])
 ```
 
-Output:
 ```
 name='get_time' function_call=[{'timezone': 'Asia/Bangkok'}] similarity_score=None
 '18:51'
 ```
 
+All local, no API calls.
+
 ## Cleanup
 
-Once done, if you'd like to delete the downloaded model you can do so with the following:
+Delete the model when you're done:
 
 ```bash
 rm ./mistral-7b-instruct-v0.2.Q4_0.gguf
-``` 
+```

--- a/docs/user-guide/guides/migration-to-v1.md
+++ b/docs/user-guide/guides/migration-to-v1.md
@@ -1,129 +1,120 @@
-The v0.1 release of semantic router introduces several breaking changes to improve the API design and add new functionality. This guide will help you migrate your code to the new version.
+v0.1 reworked the API and added new capabilities. Some of those changes are breaking. This guide covers what moved, what got renamed, and how to update your code.
 
-## Key API Changes
+## Key API changes
 
-### Module Imports and Class Renaming
+### `RouteLayer` is now `SemanticRouter`
 
-- `from semantic_router import RouteLayer` → `from semantic_router.routers import SemanticRouter`
-  
-  The `RouteLayer` class has been renamed to `SemanticRouter` and moved to the `routers` module to better reflect its purpose and fit into the modular architecture.
+```python
+# before
+from semantic_router import RouteLayer
 
-### Method Signatures
+# after
+from semantic_router.routers import SemanticRouter
+```
 
-- `SemanticRouter.add(route: Route)` → `SemanticRouter.add(routes: List[Route])`
-  
-  The `add` method now accepts a list of routes, making it easier to add multiple routes at once. However, it still supports adding a single route for backward compatibility.
+The class was renamed and moved into the `routers` module. Same job, clearer name, and it fits the modular layout alongside `HybridRouter`.
 
-  ```python
-  # Before
-  route_layer = RouteLayer(encoder=encoder)
-  route_layer.add(route1)
-  route_layer.add(route2)
-  
-  # After
-  semantic_router = SemanticRouter(encoder=encoder)
-  semantic_router.add([route1, route2])  # Add multiple routes at once
-  semantic_router.add(route3)  # Still works for a single route
-  ```
+### `add` takes a list
 
-- `RouteLayer.retrieve_multiple_routes()` → `SemanticRouter.__call__(limit=None)` or `SemanticRouter.acall(limit=None)`
+`add` now accepts a list of routes. A single route still works.
 
-  The `retrieve_multiple_routes` method has been removed. If you need similar functionality:
-  
-  - In versions 0.1.0-0.1.2: You can use the deprecated `_semantic_classify_multiple_routes` method
-  - In version 0.1.3+ (0.1.5+ is recommended): Use the `__call__` or `acall` methods with appropriate `limit` parameter.
-  
-  ```python
-  # Before (v0.0.x)
-  route_layer = RouteLayer(encoder=encoder, routes=routes)
-  multiple_routes = route_layer.retrieve_multiple_routes(query_text)
-  
-  # Transitional (v0.1.0-0.1.2)
-  # Using deprecated method (not recommended)
-  semantic_router = SemanticRouter(encoder=encoder, routes=routes, auto_sync="local")
-  query_results = semantic_router._query(query_text)
-  multiple_routes = semantic_router._semantic_classify_multiple_routes(query_results)
-  
-  # After (v0.1.3+)
-  semantic_router = SemanticRouter(encoder=encoder, routes=routes, auto_sync="local")
-  # Return all routes that pass their score thresholds
-  all_routes = semantic_router(query_text, limit=None)
-  # Or return top N routes that pass their score thresholds
-  top_routes = semantic_router(query_text, limit=3)
-  
-  # To get scores for all routes regardless of threshold
-  semantic_router.set_threshold(threshold=0.0)  # Set all route thresholds to 0
-  all_route_scores = semantic_router(query_text, limit=None)
-  ```
-  
-  When `limit=1` (the default), a single `RouteChoice` object is returned.
-  When `limit=None` or `limit > 1`, a list of `RouteChoice` objects is returned.
+```python
+# before
+route_layer = RouteLayer(encoder=encoder)
+route_layer.add(route1)
+route_layer.add(route2)
 
-  > **Important Note About `top_k`**: The `top_k` parameter (default: 5) can still limit the number of routes returned, regardless of the `limit` parameter. When using `limit > 1`, we recommend setting `top_k` to a higher value such as 100 or more. If you're using `limit=None` to get all possible results, make sure to set `top_k` to be equal to or greater than the total number of utterances shared across all of your routes.
-  >
-  > ```python
-  > # Example: Setting top_k higher when retrieving multiple routes
-  > semantic_router = SemanticRouter(encoder=encoder, routes=routes, top_k=100)
-  > all_routes = semantic_router(query_text, limit=None)
-  > ```
+# after
+semantic_router = SemanticRouter(encoder=encoder)
+semantic_router.add([route1, route2])  # several at once
+semantic_router.add(route3)            # one still works
+```
 
-### Synchronization Strategy
+### `retrieve_multiple_routes` is gone — use `limit`
 
-- If expecting routes to sync between local and remote on initialization, use `SemanticRouter(..., auto_sync="local")`. 
+To get more than one route back, call the router with a `limit`:
 
-  The `auto_sync` parameter provides control over how routes are synchronized between local and remote indexes. Read more about `auto_sync` and [synchronization strategies](../features/sync).
+```python
+# before (v0.0.x)
+route_layer = RouteLayer(encoder=encoder, routes=routes)
+multiple_routes = route_layer.retrieve_multiple_routes(query_text)
 
-  Available synchronization modes:
-  
-  - `error`: Raise an error if local and remote are not synchronized.
-  - `remote`: Take remote as the source of truth and update local to align.
-  - `local`: Take local as the source of truth and update remote to align.
-  - `merge-force-local`: Merge both local and remote keeping local as the priority.
-  - `merge-force-remote`: Merge both local and remote keeping remote as the priority.
-  - `merge`: Merge both local and remote, with local taking priority for conflicts.
+# transitional (v0.1.0–0.1.2) — deprecated, not recommended
+semantic_router = SemanticRouter(encoder=encoder, routes=routes, auto_sync="local")
+query_results = semantic_router._query(query_text)
+multiple_routes = semantic_router._semantic_classify_multiple_routes(query_results)
 
-  ```python
-  # Example: Initialize with synchronization strategy
-  semantic_router = SemanticRouter(
-      encoder=encoder,
-      routes=routes,
-      index=PineconeIndex(...),
-      auto_sync="local"  # Local routes will be used to update the remote index
-  )
-  ```
+# after (v0.1.3+, 0.1.5+ recommended)
+semantic_router = SemanticRouter(encoder=encoder, routes=routes, auto_sync="local")
+all_routes = semantic_router(query_text, limit=None)  # every route that passes its threshold
+top_routes = semantic_router(query_text, limit=3)     # the top 3 that pass
 
-## Other Important Changes
+# to score every route regardless of threshold
+semantic_router.set_threshold(threshold=0.0)
+all_route_scores = semantic_router(query_text, limit=None)
+```
 
-### Router Configuration
+With `limit=1` (the default) you get a single `RouteChoice`. With `limit=None` or `limit > 1` you get a list.
 
-The `RouterConfig` class has been introduced as a replacement for the `LayerConfig` class, providing a more flexible way to configure routers:
+> **Watch `top_k`.** It defaults to 5 and caps how many routes come back, independently of `limit`. If you use `limit > 1`, raise `top_k` — 100 or more is reasonable. If you use `limit=None` to get everything, set `top_k` to at least the total number of utterances across all your routes.
+>
+> ```python
+> semantic_router = SemanticRouter(encoder=encoder, routes=routes, top_k=100)
+> all_routes = semantic_router(query_text, limit=None)
+> ```
+
+### Sync is now explicit
+
+If you expect local and remote routes to sync at startup, say so with `auto_sync`:
+
+```python
+semantic_router = SemanticRouter(
+    encoder=encoder,
+    routes=routes,
+    index=PineconeIndex(...),
+    auto_sync="local",  # push local routes to the remote index
+)
+```
+
+The modes:
+
+- `error` — raise if local and remote differ.
+- `remote` — remote wins; update local.
+- `local` — local wins; update remote.
+- `merge-force-local` — merge, local takes priority.
+- `merge-force-remote` — merge, remote takes priority.
+- `merge` — merge, local wins on conflicts.
+
+The [sync guide](../features/sync) explains each in depth.
+
+## Other changes
+
+### `RouterConfig` replaces `LayerConfig`
 
 ```python
 from semantic_router.routers import RouterConfig
 
-# Create configuration for your router
 config = RouterConfig(
     routes=[route1, route2],
     encoder_type="openai",
-    encoder_name="text-embedding-3-small"
+    encoder_name="text-embedding-3-small",
 )
 
-# Initialize a router from config
 semantic_router = SemanticRouter.from_config(config)
 ```
 
-### Advanced Router Options
+### More router types
 
-The modular architecture now provides access to different router types:
+The modular layout exposes:
 
-- `SemanticRouter`: The standard router that replaces the old `RouteLayer`
-- `HybridRouter`: A router that can combine dense and sparse embedding methods
-- `BaseRouter`: An abstract base class for creating custom routers
+- `SemanticRouter` — the standard router (the old `RouteLayer`).
+- `HybridRouter` — dense plus sparse embeddings.
+- `BaseRouter` — an abstract base for your own routers.
 
-## Migration Example
+## Before and after
 
 ```python
-# Before (v0.0.x)
+# before (v0.0.x)
 from semantic_router import RouteLayer, Route
 from semantic_router.encoders import OpenAIEncoder
 
@@ -132,13 +123,13 @@ layer = RouteLayer(encoder=OpenAIEncoder())
 layer.add(route)
 result = layer("query text")
 
-# After (v0.1.x)
+# after (v0.1.x)
 from semantic_router import Route
 from semantic_router.routers import SemanticRouter
 from semantic_router.encoders import OpenAIEncoder
 
 route = Route(name="example", utterances=["sample utterance"])
 router = SemanticRouter(encoder=OpenAIEncoder())
-router.add(route)  # Still works for a single route
+router.add(route)
 result = router("query text")
-``` 
+```

--- a/docs/user-guide/guides/save-load-from-file.md
+++ b/docs/user-guide/guides/save-load-from-file.md
@@ -1,41 +1,29 @@
-Route layers can be saved to and loaded from files. This can be useful if we want to save a route layer to a file for later use, or if we want to load a route layer from a file.
+You can save a router to a file and load it back later — useful for shipping the same routes between environments, or just for not rebuilding them every time.
 
-We can save and load route layers to/from YAML or JSON files. For JSON we do:
+JSON and YAML both work.
 
 ```python
-# save to JSON
+# JSON
 router.to_json("router.json")
-# load from JSON
 new_router = SemanticRouter.from_json("router.json")
-```
 
-For YAML we do:
-
-```python
-# save to YAML
+# YAML
 router.to_yaml("router.yaml")
-# load from YAML
 new_router = SemanticRouter.from_yaml("router.yaml")
 ```
 
-The saved files contain all the information needed to initialize new semantic routers. If you are using a remote index, you can use the [sync features](../features/sync) to keep the router in sync with the index.
+The file holds everything needed to recreate the router. If you use a remote index, the [sync features](../features/sync) keep the loaded router and the index in step.
 
-## Full Example
+## Full example
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/aurelio-labs/semantic-router/blob/main/docs/01-save-load-from-file.ipynb)
 [![Open nbviewer](https://raw.githubusercontent.com/pinecone-io/examples/master/assets/nbviewer-shield.svg)](https://nbviewer.org/github/aurelio-labs/semantic-router/blob/main/docs/01-save-load-from-file.ipynb)
-
-Here we will show how to save routers to YAML or JSON files, and how to load a router from file.
-
-We start by installing the library:
 
 ```bash
 !pip install -qU semantic-router
 ```
 
-## Define Route
-
-First let's create a list of routes:
+## Build a router
 
 ```python
 from semantic_router import Route
@@ -65,8 +53,6 @@ chitchat = Route(
 routes = [politics, chitchat]
 ```
 
-We define a semantic router using these routes and using the Cohere encoder.
-
 ```python
 import os
 from getpass import getpass
@@ -83,13 +69,12 @@ encoder = CohereEncoder()
 router = SemanticRouter(encoder=encoder, routes=routes, auto_sync="local")
 ```
 
-## Test Route
+Quick check that it works:
 
 ```python
 router("isn't politics the best thing ever")
 ```
 
-Output:
 ```
 RouteChoice(name='politics', function_call=None, similarity_score=None)
 ```
@@ -98,22 +83,19 @@ RouteChoice(name='politics', function_call=None, similarity_score=None)
 router("how's the weather today?")
 ```
 
-Output:
 ```
 RouteChoice(name='chitchat', function_call=None, similarity_score=None)
 ```
 
-## Save To JSON
-
-To save our semantic router we call the `to_json` method:
+## Save it
 
 ```python
 router.to_json("router.json")
 ```
 
-## Loading from JSON
+## Load it
 
-We can view the router file we just saved to see what information is stored.
+Have a look at what got saved:
 
 ```python
 import json
@@ -124,13 +106,13 @@ with open("router.json", "r") as f:
 print(router_json)
 ```
 
-It tells us our encoder type, encoder name, and routes. This is everything we need to initialize a new router. To do so, we use the `from_json` method.
+Encoder type, encoder name, and the routes — everything a new router needs. Load it with `from_json`:
 
 ```python
 router = SemanticRouter.from_json("router.json")
 ```
 
-We can confirm that our router has been initialized with the expected attributes by viewing the `SemanticRouter` object:
+Confirm it came back intact:
 
 ```python
 print(
@@ -140,15 +122,12 @@ print(
 )
 ```
 
----
-
-## Test Route Again
+And that it still routes:
 
 ```python
 router("isn't politics the best thing ever")
 ```
 
-Output:
 ```
 RouteChoice(name='politics', function_call=None, similarity_score=None)
 ```
@@ -157,7 +136,6 @@ RouteChoice(name='politics', function_call=None, similarity_score=None)
 router("how's the weather today?")
 ```
 
-Output:
 ```
 RouteChoice(name='chitchat', function_call=None, similarity_score=None)
-``` 
+```

--- a/docs/user-guide/guides/semantic-router.md
+++ b/docs/user-guide/guides/semantic-router.md
@@ -1,11 +1,8 @@
-The `SemanticRouter` is the main class of the semantic router. It is responsible
-for making decisions about which route to take based on an input utterance.
-A `SemanticRouter` consists of an `encoder`, an `index`, and a list of `routes`.
-Route layers that include dynamic routes (i.e. routes that can generate dynamic
-decision outputs) also include an `llm`.
+The `SemanticRouter` is the heart of the library. Give it a query and it decides which route to take. It's built from three things: an `encoder`, an `index`, and a list of `routes`. If any of your routes are dynamic (they produce function calls), it also holds an `llm`.
 
-To use a `SemanticRouter` we first need some `routes`. We can initialize them like
-so:
+## Routes
+
+Start with some routes:
 
 ```python
 from semantic_router import Route
@@ -32,10 +29,13 @@ chitchat = Route(
         "let's go to the chippy",
     ],
 )
+
+routes = [politics, chitchat]
 ```
 
-We initialize an encoder — there are many options available here, from local
-to API-based. For now we'll use the `OpenAIEncoder`.
+## Encoder
+
+There are plenty of encoders to choose from, local and API-based. We'll use `OpenAIEncoder` here:
 
 ```python
 import os
@@ -46,17 +46,15 @@ os.environ["OPENAI_API_KEY"] = "<YOUR_API_KEY>"
 encoder = OpenAIEncoder()
 ```
 
-Now we define the `RouteLayer`. When called, the route layer will consume text
-(a query) and output the category (`Route`) it belongs to — to initialize a
-`RouteLayer` we need our `encoder` model and a list of `routes`.
+## The router
+
+Pass in the encoder and routes. When you call the router with a query, it returns the `Route` the query belongs to.
 
 ```python
 from semantic_router import SemanticRouter
 
 sr = SemanticRouter(encoder=encoder, routes=routes, auto_sync="local")
 ```
-
-Now we can call the `RouteLayer` with an input query:
 
 ```python
 sr("don't you love politics?")
@@ -66,11 +64,7 @@ sr("don't you love politics?")
 [Out]: RouteChoice(name='politics', function_call=None, similarity_score=None)
 ```
 
-The output is a `RouteChoice` object, which contains the name of the route,
-the function call (if any), and the similarity score that triggered the route
-choice.
-
-We can try another query:
+You get back a `RouteChoice`. It holds the route name, any function call (for dynamic routes), and the similarity score that triggered the match.
 
 ```python
 sr("how's the weather today?")
@@ -80,8 +74,7 @@ sr("how's the weather today?")
 [Out]: RouteChoice(name='chitchat', function_call=None, similarity_score=None)
 ```
 
-Both are classified accurately, what if we send a query that is unrelated to
-our existing Route objects?
+Both right. Now something that matches neither route:
 
 ```python
 sr("I'm interested in learning about llama 3")
@@ -91,14 +84,14 @@ sr("I'm interested in learning about llama 3")
 [Out]: RouteChoice(name=None, function_call=None, similarity_score=None)
 ```
 
-In this case, the `RouteLayer` is unable to find a route that matches the
-input query and so returns a `RouteChoice` with `name=None`.
+No route cleared its threshold, so `name` is `None`.
 
-We can also retrieve multiple routes with their associated score using
-`retrieve_multiple_routes`:
+## Getting more than one route
+
+By default the router returns the single best match. Pass `limit` to get several, each with its score. `limit=None` returns every route that passes its threshold; `limit=3` returns the top three.
 
 ```python
-sr.retrieve_multiple_routes("Hi! How are you doing in politics??")
+sr("Hi! How are you doing in politics??", limit=None)
 ```
 
 ```
@@ -106,15 +99,16 @@ sr.retrieve_multiple_routes("Hi! How are you doing in politics??")
         RouteChoice(name='chitchat', function_call=None, similarity_score=0.835)]
 ```
 
-If `retrieve_multiple_routes` is called with a query that does not match any
-routes, it will return an empty list:
+If nothing passes, you get an empty list:
 
 ```python
-sr.retrieve_multiple_routes("I'm interested in learning about llama 3")
+sr("I'm interested in learning about llama 3", limit=None)
 ```
 
 ```
 [Out]: []
 ```
 
-You can find an introductory notebook for the [route layer here](https://github.com/aurelio-labs/semantic-router/blob/main/docs/00-introduction.ipynb). 
+> One thing to watch: `top_k` (default 5) caps how many routes are considered, independently of `limit`. If you're using `limit > 1` or `limit=None`, raise `top_k` — for example `SemanticRouter(..., top_k=100)`.
+
+The [introductory notebook](https://github.com/aurelio-labs/semantic-router/blob/main/docs/00-introduction.ipynb) walks through all of this end to end.


### PR DESCRIPTION
## Summary

Rewrites every guide page (`docs/get-started` + `docs/user-guide`) in a clearer, more direct voice — short, varied sentences, signal over noise, written as if explaining to someone. Prose only; code examples and mermaid diagrams are preserved (with the fixes below).

## Accuracy fixes found while reviewing

- **`guides/semantic-router.md`** — replaced the removed `retrieve_multiple_routes` with `limit=None`; `RouteLayer` → `SemanticRouter`.
- **`quickstart.md`** — removed the stale "we currently support Cohere and OpenAI" note, the `RouteLayer`/`HybridRouteLayer` naming, and the nonexistent `[hybrid]` extra.
- **`components/encoders.md`** — table now lists all 21 encoders (adds Jina, Voyage, NIM, LiteLLM, Ollama, `LocalEncoder`, `LocalSparseEncoder`). `CLIPEncoder`/`VitEncoder` now correctly marked as needing `[local]` (they import torch).
- **`components/indexes.md`** — removed the nonexistent `[hybrid]` extra.
- Encoder/index tables link to the docs-site client reference instead of the dead `semantic-router.aurelio.ai`.
- **`features/sync.md`** — fixed `semantic_router.indexes` → `semantic_router.index`; removed stray ASCII art; example uses env vars instead of undefined variables.
- Fixed a missing comma (implicit string concatenation bug) in the `politics` utterances in `threshold-optimization` and `local-execution`.
- **`features/dynamic-routes.md`** — removed the duplicated `get_time` setup.
- Dropped the dead `index.html` docs link in the intro; fixed a changelog typo.

## Review notes

Every API claim in the rewrite was checked against `semantic_router/` on `main` (exports, router methods, `__call__(limit=...)`, encoder class names, extras in `pyproject.toml`). Content changes flow to docs.aurelio.ai via the existing `docs.yml` sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cnLKN8D7KYcMspnckT2zS